### PR TITLE
Popup progress

### DIFF
--- a/NeuroAccessMaui/App.xaml.cs
+++ b/NeuroAccessMaui/App.xaml.cs
@@ -4,7 +4,6 @@ using System.Reflection;
 using System.Text;
 using EDaler;
 using Microsoft.Maui.Controls.Internals;
-using Mopups.Services;
 using NeuroAccessMaui.Extensions;
 using NeuroAccessMaui.Resources.Languages;
 using NeuroAccessMaui.Services;
@@ -17,12 +16,14 @@ using NeuroAccessMaui.Services.Navigation;
 using NeuroAccessMaui.Services.Network;
 using NeuroAccessMaui.Services.Nfc;
 using NeuroAccessMaui.Services.Notification;
+using NeuroAccessMaui.Services.Popup;
 using NeuroAccessMaui.Services.Settings;
 using NeuroAccessMaui.Services.Storage;
 using NeuroAccessMaui.Services.Tag;
 using NeuroAccessMaui.Services.UI;
 using NeuroAccessMaui.Services.UI.QR;
 using NeuroAccessMaui.Services.Xmpp;
+using NeuroAccessMaui.Services.Screenshot;
 using NeuroAccessMaui.UI.Pages;
 using NeuroAccessMaui.UI.Pages.Main;
 using NeuroAccessMaui.UI.Popups.Pin;
@@ -309,6 +310,8 @@ namespace NeuroAccessMaui
 			Types.InstantiateDefault<IContractOrchestratorService>(false);
 			Types.InstantiateDefault<INfcService>(false);
 			Types.InstantiateDefault<INotificationService>(false);
+			Types.InstantiateDefault<IPopupService>(false);
+			Types.InstantiateDefault<IScreenshotService>(false);
 
 			defaultInstantiatedSource.TrySetResult(true);
 

--- a/NeuroAccessMaui/App.xaml.cs
+++ b/NeuroAccessMaui/App.xaml.cs
@@ -935,11 +935,9 @@ namespace NeuroAccessMaui
 				if (!Profile.HasPin)
 					return string.Empty;
 
-				CheckPinViewModel ViewModel = new();
-				CheckPinPopup Page = new(ViewModel);
-				await MopupService.Instance.PushAsync(Page);
+				string? result = await ServiceRef.PopupService.PushAsync<CheckPinPopup, CheckPinViewModel, string>();
 				await CheckUserBlocking();
-				return await ViewModel.Result;
+				return result;
 			}
 			catch (Exception)
 			{

--- a/NeuroAccessMaui/NeuroAccessMaui.csproj
+++ b/NeuroAccessMaui/NeuroAccessMaui.csproj
@@ -266,11 +266,11 @@
 	  <Compile Update="UI\Popups\Pin\CheckPinPopup.xaml.cs">
 	    <DependentUpon>CheckPinPopup.xaml</DependentUpon>
 	  </Compile>
-	  <Compile Update="UI\Popups\SelectLanguagePopup.xaml.cs">
-	    <DependentUpon>SelectLanguagePopup.xaml</DependentUpon>
-	  </Compile>
 	  <Compile Update="UI\Popups\SelectPhoneCodePopup.xaml.cs">
 	    <DependentUpon>SelectPhoneCodePopup.xaml</DependentUpon>
+	  </Compile>
+	  <Compile Update="UI\Popups\Settings\SelectLanguagePopup.xaml.cs">
+	    <DependentUpon>SelectLanguagePopup.xaml</DependentUpon>
 	  </Compile>
 	  <Compile Update="UI\Popups\ShowInfoPopup.xaml.cs">
 	    <DependentUpon>ShowInfoPopup.xaml</DependentUpon>
@@ -453,6 +453,9 @@
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="UI\Popups\Pin\CheckPinPopup.xaml">
+	    <Generator>MSBuild:Compile</Generator>
+	  </MauiXaml>
+	  <MauiXaml Update="UI\Popups\Settings\SelectLanguagePopup.xaml">
 	    <Generator>MSBuild:Compile</Generator>
 	  </MauiXaml>
 	  <MauiXaml Update="UI\Popups\Tokens\AddTextNote\AddTextNotePopup.xaml">

--- a/NeuroAccessMaui/Services/Popup/IPopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/IPopupService.cs
@@ -65,6 +65,14 @@ namespace NeuroAccessMaui.Services.Popup
 			where TPage : BasePopup, new();
 
 		/// <summary>
+		/// Pushes a popup, without any viewmodel binding, onto the current view
+		/// </summary>
+		/// <typeparam name="TPage">The type of the page view</typeparam>
+		/// <returns></returns>
+		Task PushAsync<TPage>(TPage page)
+			where TPage : BasePopup;
+
+		/// <summary>
 		/// Pushes a popup onto the current view
 		/// </summary>
 		/// <typeparam name="TPage">The type of the page view</typeparam>

--- a/NeuroAccessMaui/Services/Popup/IPopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/IPopupService.cs
@@ -1,0 +1,116 @@
+﻿using NeuroAccessMaui.UI.Popups;
+using Waher.Runtime.Inventory;
+
+namespace NeuroAccessMaui.Services.Popup
+{
+
+	/// <summary>
+	/// A wrapper allowing the displaying of and retrieving data from popups.
+	/// An effort to decouple implementation from the use of libraries.
+	/// </summary>
+	[DefaultImplementation(typeof(PopupService))]
+	public interface IPopupService
+	{
+		/// <summary>
+		/// Pushes a popup onto the current view
+		/// </summary>
+		/// <typeparam name="TPage">The type of the page view</typeparam>
+		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
+		Task PushPopup<TPage, TViewModel>()
+			where TViewModel : BasePopupViewModel, new()
+			where TPage : BasePopup, new();
+
+		/// <summary>
+		/// Pushes a popup onto the current view
+		/// </summary>
+		/// <typeparam name="TPage">The type of the page view</typeparam>
+		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
+		/// <param name="page">An instance of the page view</param>
+		/// <param name="viewModel">An instance of the viewmodel</param>
+		/// <returns></returns>
+		Task PushPopup<TPage, TViewModel>(TPage page, TViewModel viewModel)
+			where TViewModel : BasePopupViewModel
+			where TPage : BasePopup;
+
+		/// <summary>
+		/// Pushes a popup onto the current view
+		/// </summary>
+		/// <typeparam name="TPage">The type of the page view</typeparam>
+		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
+		/// <param name="page">An instance of the page view</param>
+		/// <returns></returns>
+		Task PushPopup<TPage, TViewModel>(TPage page)
+			where TViewModel : BasePopupViewModel, new()
+			where TPage : BasePopup;
+
+		/// <summary>
+		/// Pushes a popup onto the current view
+		/// </summary>
+		/// <typeparam name="TPage">The type of the page view</typeparam>
+		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
+		/// <param name="viewModel">An instance of the viewmodel</param>
+		/// <returns></returns>
+		Task PushPopup<TPage, TViewModel>(TViewModel viewModel)
+			where TViewModel : BasePopupViewModel
+			where TPage : BasePopup, new();
+
+		/// <summary>
+		/// Pushes a popup, without any viewmodel binding, onto the current view
+		/// </summary>
+		/// <typeparam name="TPage">The type of the page view</typeparam>
+		/// <returns></returns>
+		Task PushPopup<TPage>()
+			where TPage : BasePopup, new();
+
+		/// <summary>
+		/// Pushes a popup onto the current view
+		/// </summary>
+		/// <typeparam name="TPage">The type of the page view</typeparam>
+		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
+		/// <typeparam name="TReturn">The return value of the TViewModel</typeparam>
+		/// <returns></returns>
+		Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>()
+			where TViewModel : ReturningPopupViewModel<TReturn>, new()
+			where TPage : BasePopup, new();
+
+		/// <summary>
+		/// Pushes a popup onto the current view
+		/// </summary>
+		/// <typeparam name="TPage">The type of the page view</typeparam>
+		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
+		/// <typeparam name="TReturn">The return value of the TViewModel</typeparam>
+		/// <param name="page">An instance of the page view</param>
+		/// <param name="viewModel">An instance of the viewmodel</param>
+		/// <returns></returns>
+		Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel)
+			where TViewModel : ReturningPopupViewModel<TReturn>
+			where TPage : BasePopup;
+
+		/// <summary>
+		/// Pushes a popup onto the current view
+		/// </summary>
+		/// <typeparam name="TPage">The type of the page view</typeparam>
+		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
+		/// <typeparam name="TReturn">The return value of the TViewModel</typeparam>
+		/// <param name="page">An instance of the page view</param>
+		/// <returns></returns>
+		Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TPage page)
+			where TViewModel : ReturningPopupViewModel<TReturn>, new()
+			where TPage : BasePopup;
+
+		/// <summary>
+		/// Pushes a popup onto the current view
+		/// </summary>
+		/// <typeparam name="TPage">The type of the page view</typeparam>
+		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
+		/// <typeparam name="TReturn">The return value of the TViewModel</typeparam>
+		/// <param name="viewModel">An instance of the viewmodel</param>
+		/// <returns></returns>
+		Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TViewModel viewModel)
+			where TViewModel : ReturningPopupViewModel<TReturn>
+			where TPage : BasePopup, new();
+
+		Task PopPopup();
+
+	}
+}

--- a/NeuroAccessMaui/Services/Popup/IPopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/IPopupService.cs
@@ -18,7 +18,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// </summary>
 		/// <typeparam name="TPage">The type of the page view</typeparam>
 		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
-		Task PushPopupAsync<TPage, TViewModel>()
+		Task PushAsync<TPage, TViewModel>()
 			where TViewModel : BasePopupViewModel, new()
 			where TPage : BasePopup, new();
 
@@ -30,7 +30,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <param name="page">An instance of the page view</param>
 		/// <param name="viewModel">An instance of the viewmodel</param>
 		/// <returns></returns>
-		Task PushPopupAsync<TPage, TViewModel>(TPage page, TViewModel viewModel)
+		Task PushAsync<TPage, TViewModel>(TPage page, TViewModel viewModel)
 			where TViewModel : BasePopupViewModel
 			where TPage : BasePopup;
 
@@ -41,7 +41,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
 		/// <param name="page">An instance of the page view</param>
 		/// <returns></returns>
-		Task PushPopupAsync<TPage, TViewModel>(TPage page)
+		Task PushAsync<TPage, TViewModel>(TPage page)
 			where TViewModel : BasePopupViewModel, new()
 			where TPage : BasePopup;
 
@@ -52,7 +52,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
 		/// <param name="viewModel">An instance of the viewmodel</param>
 		/// <returns></returns>
-		Task PushPopupAsync<TPage, TViewModel>(TViewModel viewModel)
+		Task PushAsync<TPage, TViewModel>(TViewModel viewModel)
 			where TViewModel : BasePopupViewModel
 			where TPage : BasePopup, new();
 
@@ -61,7 +61,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// </summary>
 		/// <typeparam name="TPage">The type of the page view</typeparam>
 		/// <returns></returns>
-		Task PushPopupAsync<TPage>()
+		Task PushAsync<TPage>()
 			where TPage : BasePopup, new();
 
 		/// <summary>
@@ -71,7 +71,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
 		/// <typeparam name="TReturn">The return value of the TViewModel</typeparam>
 		/// <returns></returns>
-		Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>()
+		Task<TReturn?> PushAsync<TPage, TViewModel, TReturn>()
 			where TViewModel : ReturningPopupViewModel<TReturn>, new()
 			where TPage : BasePopup, new();
 
@@ -84,7 +84,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <param name="page">An instance of the page view</param>
 		/// <param name="viewModel">An instance of the viewmodel</param>
 		/// <returns></returns>
-		Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel)
+		Task<TReturn?> PushAsync<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel)
 			where TViewModel : ReturningPopupViewModel<TReturn>
 			where TPage : BasePopup;
 
@@ -96,7 +96,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <typeparam name="TReturn">The return value of the TViewModel</typeparam>
 		/// <param name="page">An instance of the page view</param>
 		/// <returns></returns>
-		Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TPage page)
+		Task<TReturn?> PushAsync<TPage, TViewModel, TReturn>(TPage page)
 			where TViewModel : ReturningPopupViewModel<TReturn>, new()
 			where TPage : BasePopup;
 
@@ -108,11 +108,11 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <typeparam name="TReturn">The return value of the TViewModel</typeparam>
 		/// <param name="viewModel">An instance of the viewmodel</param>
 		/// <returns></returns>
-		Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TViewModel viewModel)
+		Task<TReturn?> PushAsync<TPage, TViewModel, TReturn>(TViewModel viewModel)
 			where TViewModel : ReturningPopupViewModel<TReturn>
 			where TPage : BasePopup, new();
 
-		Task PopPopupAsync();
+		Task PopAsync();
 
 	}
 }

--- a/NeuroAccessMaui/Services/Popup/IPopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/IPopupService.cs
@@ -16,7 +16,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// </summary>
 		/// <typeparam name="TPage">The type of the page view</typeparam>
 		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
-		Task PushPopup<TPage, TViewModel>()
+		Task PushPopupAsync<TPage, TViewModel>()
 			where TViewModel : BasePopupViewModel, new()
 			where TPage : BasePopup, new();
 
@@ -28,7 +28,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <param name="page">An instance of the page view</param>
 		/// <param name="viewModel">An instance of the viewmodel</param>
 		/// <returns></returns>
-		Task PushPopup<TPage, TViewModel>(TPage page, TViewModel viewModel)
+		Task PushPopupAsync<TPage, TViewModel>(TPage page, TViewModel viewModel)
 			where TViewModel : BasePopupViewModel
 			where TPage : BasePopup;
 
@@ -39,7 +39,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
 		/// <param name="page">An instance of the page view</param>
 		/// <returns></returns>
-		Task PushPopup<TPage, TViewModel>(TPage page)
+		Task PushPopupAsync<TPage, TViewModel>(TPage page)
 			where TViewModel : BasePopupViewModel, new()
 			where TPage : BasePopup;
 
@@ -50,7 +50,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
 		/// <param name="viewModel">An instance of the viewmodel</param>
 		/// <returns></returns>
-		Task PushPopup<TPage, TViewModel>(TViewModel viewModel)
+		Task PushPopupAsync<TPage, TViewModel>(TViewModel viewModel)
 			where TViewModel : BasePopupViewModel
 			where TPage : BasePopup, new();
 
@@ -59,7 +59,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// </summary>
 		/// <typeparam name="TPage">The type of the page view</typeparam>
 		/// <returns></returns>
-		Task PushPopup<TPage>()
+		Task PushPopupAsync<TPage>()
 			where TPage : BasePopup, new();
 
 		/// <summary>
@@ -69,7 +69,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <typeparam name="TViewModel">The type of the viewmodel to bind to the page view</typeparam>
 		/// <typeparam name="TReturn">The return value of the TViewModel</typeparam>
 		/// <returns></returns>
-		Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>()
+		Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>()
 			where TViewModel : ReturningPopupViewModel<TReturn>, new()
 			where TPage : BasePopup, new();
 
@@ -82,7 +82,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <param name="page">An instance of the page view</param>
 		/// <param name="viewModel">An instance of the viewmodel</param>
 		/// <returns></returns>
-		Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel)
+		Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel)
 			where TViewModel : ReturningPopupViewModel<TReturn>
 			where TPage : BasePopup;
 
@@ -94,7 +94,7 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <typeparam name="TReturn">The return value of the TViewModel</typeparam>
 		/// <param name="page">An instance of the page view</param>
 		/// <returns></returns>
-		Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TPage page)
+		Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TPage page)
 			where TViewModel : ReturningPopupViewModel<TReturn>, new()
 			where TPage : BasePopup;
 
@@ -106,11 +106,11 @@ namespace NeuroAccessMaui.Services.Popup
 		/// <typeparam name="TReturn">The return value of the TViewModel</typeparam>
 		/// <param name="viewModel">An instance of the viewmodel</param>
 		/// <returns></returns>
-		Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TViewModel viewModel)
+		Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TViewModel viewModel)
 			where TViewModel : ReturningPopupViewModel<TReturn>
 			where TPage : BasePopup, new();
 
-		Task PopPopup();
+		Task PopPopupAsync();
 
 	}
 }

--- a/NeuroAccessMaui/Services/Popup/IPopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/IPopupService.cs
@@ -1,5 +1,6 @@
 ﻿using NeuroAccessMaui.UI.Popups;
 using Waher.Runtime.Inventory;
+using Waher.Script.Content.Functions.InputOutput;
 
 namespace NeuroAccessMaui.Services.Popup
 {
@@ -11,6 +12,7 @@ namespace NeuroAccessMaui.Services.Popup
 	[DefaultImplementation(typeof(PopupService))]
 	public interface IPopupService
 	{
+
 		/// <summary>
 		/// Pushes a popup onto the current view
 		/// </summary>

--- a/NeuroAccessMaui/Services/Popup/PopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/PopupService.cs
@@ -50,10 +50,7 @@ namespace NeuroAccessMaui.Services.Popup
 		{
 			TPage page = new();
 			BasePopupViewModel? viewModel = page.ViewModel;
-			if(viewModel is not null)
-				this.viewModelStack.Push(viewModel);
-			else
-				this.viewModelStack.Push(null);
+			this.viewModelStack.Push(viewModel ?? null);
 			return MopupService.Instance.PushAsync(page);
 		}
 
@@ -61,10 +58,7 @@ namespace NeuroAccessMaui.Services.Popup
 		public Task PushAsync<TPage>(TPage page) where TPage : BasePopup
 		{
 			BasePopupViewModel? viewModel = page.ViewModel;
-			if (viewModel is not null)
-				this.viewModelStack.Push(viewModel);
-			else
-				this.viewModelStack.Push(null);
+			this.viewModelStack.Push(viewModel ?? null);
 			return MopupService.Instance.PushAsync(page);
 		}
 

--- a/NeuroAccessMaui/Services/Popup/PopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/PopupService.cs
@@ -8,7 +8,7 @@ namespace NeuroAccessMaui.Services.Popup
 	public class PopupService : IPopupService
 	{
 		/// <inheritdoc/>
-		public Task PushPopup<TPage, TViewModel>() where TPage : BasePopup, new() where TViewModel : BasePopupViewModel, new()
+		public Task PushPopupAsync<TPage, TViewModel>() where TPage : BasePopup, new() where TViewModel : BasePopupViewModel, new()
 		{
 			TPage page = new();
 			TViewModel viewModel = new();
@@ -18,14 +18,14 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public Task PushPopup<TPage, TViewModel>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : BasePopupViewModel
+		public Task PushPopupAsync<TPage, TViewModel>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : BasePopupViewModel
 		{
 			page.ViewModel = viewModel;
 			return MopupService.Instance.PushAsync(page);
 		}
 
 		/// <inheritdoc/>
-		public Task PushPopup<TPage, TViewModel>(TPage page) where TPage : BasePopup where TViewModel : BasePopupViewModel, new()
+		public Task PushPopupAsync<TPage, TViewModel>(TPage page) where TPage : BasePopup where TViewModel : BasePopupViewModel, new()
 		{
 			TViewModel viewModel = new();
 			page.ViewModel = viewModel;
@@ -33,7 +33,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public Task PushPopup<TPage, TViewModel>(TViewModel viewModel) where TPage : BasePopup, new() where TViewModel : BasePopupViewModel
+		public Task PushPopupAsync<TPage, TViewModel>(TViewModel viewModel) where TPage : BasePopup, new() where TViewModel : BasePopupViewModel
 		{
 			TPage page = new();
 			page.ViewModel = viewModel;
@@ -41,14 +41,14 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public Task PushPopup<TPage>() where TPage : BasePopup, new()
+		public Task PushPopupAsync<TPage>() where TPage : BasePopup, new()
 		{
 			TPage page = new();
 			return MopupService.Instance.PushAsync(page);
 		}
 
 		/// <inheritdoc/>
-		public async Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>() where TPage : BasePopup, new() where TViewModel : ReturningPopupViewModel<TReturn>, new()
+		public async Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>() where TPage : BasePopup, new() where TViewModel : ReturningPopupViewModel<TReturn>, new()
 		{
 			TPage page = new();
 			TViewModel viewModel = new();
@@ -59,7 +59,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public async Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : ReturningPopupViewModel<TReturn>
+		public async Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : ReturningPopupViewModel<TReturn>
 		{
 			page.ViewModel = viewModel;
 			await MopupService.Instance.PushAsync(page);
@@ -67,7 +67,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public async Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TPage page) where TPage : BasePopup
+		public async Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TPage page) where TPage : BasePopup
 			where TViewModel : ReturningPopupViewModel<TReturn>, new()
 		{
 			TViewModel viewModel = new();
@@ -77,7 +77,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public async Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TViewModel viewModel) where TPage : BasePopup, new() where TViewModel : ReturningPopupViewModel<TReturn>
+		public async Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TViewModel viewModel) where TPage : BasePopup, new() where TViewModel : ReturningPopupViewModel<TReturn>
 		{
 			TPage page = new();
 			page.ViewModel = viewModel;
@@ -85,7 +85,7 @@ namespace NeuroAccessMaui.Services.Popup
 			return await viewModel.Result;
 		}
 
-		public async Task PopPopup()
+		public async Task PopPopupAsync()
 		{
 			await MopupService.Instance.PopAsync();
 		}

--- a/NeuroAccessMaui/Services/Popup/PopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/PopupService.cs
@@ -49,7 +49,22 @@ namespace NeuroAccessMaui.Services.Popup
 		public Task PushAsync<TPage>() where TPage : BasePopup, new()
 		{
 			TPage page = new();
-			this.viewModelStack.Push(null);
+			BasePopupViewModel? viewModel = page.ViewModel;
+			if(viewModel is not null)
+				this.viewModelStack.Push(viewModel);
+			else
+				this.viewModelStack.Push(null);
+			return MopupService.Instance.PushAsync(page);
+		}
+
+		/// <inheritdoc/>
+		public Task PushAsync<TPage>(TPage page) where TPage : BasePopup
+		{
+			BasePopupViewModel? viewModel = page.ViewModel;
+			if (viewModel is not null)
+				this.viewModelStack.Push(viewModel);
+			else
+				this.viewModelStack.Push(null);
 			return MopupService.Instance.PushAsync(page);
 		}
 
@@ -103,5 +118,7 @@ namespace NeuroAccessMaui.Services.Popup
 			vm?.OnPop();
 			await MopupService.Instance.PopAsync();
 		}
+
+
 	}
 }

--- a/NeuroAccessMaui/Services/Popup/PopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/PopupService.cs
@@ -10,7 +10,7 @@ namespace NeuroAccessMaui.Services.Popup
 		protected readonly Stack<BasePopupViewModel?> viewModelStack = new();
 
 		/// <inheritdoc/>
-		public Task PushPopupAsync<TPage, TViewModel>() where TPage : BasePopup, new() where TViewModel : BasePopupViewModel, new()
+		public Task PushAsync<TPage, TViewModel>() where TPage : BasePopup, new() where TViewModel : BasePopupViewModel, new()
 		{
 			TPage page = new();
 			TViewModel viewModel = new();
@@ -20,7 +20,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public Task PushPopupAsync<TPage, TViewModel>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : BasePopupViewModel
+		public Task PushAsync<TPage, TViewModel>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : BasePopupViewModel
 		{
 			page.ViewModel = viewModel;
 			this.viewModelStack.Push(viewModel);
@@ -28,7 +28,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public Task PushPopupAsync<TPage, TViewModel>(TPage page) where TPage : BasePopup where TViewModel : BasePopupViewModel, new()
+		public Task PushAsync<TPage, TViewModel>(TPage page) where TPage : BasePopup where TViewModel : BasePopupViewModel, new()
 		{
 			TViewModel viewModel = new();
 			page.ViewModel = viewModel;
@@ -37,7 +37,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public Task PushPopupAsync<TPage, TViewModel>(TViewModel viewModel) where TPage : BasePopup, new() where TViewModel : BasePopupViewModel
+		public Task PushAsync<TPage, TViewModel>(TViewModel viewModel) where TPage : BasePopup, new() where TViewModel : BasePopupViewModel
 		{
 			TPage page = new();
 			page.ViewModel = viewModel;
@@ -46,7 +46,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public Task PushPopupAsync<TPage>() where TPage : BasePopup, new()
+		public Task PushAsync<TPage>() where TPage : BasePopup, new()
 		{
 			TPage page = new();
 			this.viewModelStack.Push(null);
@@ -54,7 +54,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public async Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>() where TPage : BasePopup, new() where TViewModel : ReturningPopupViewModel<TReturn>, new()
+		public async Task<TReturn?> PushAsync<TPage, TViewModel, TReturn>() where TPage : BasePopup, new() where TViewModel : ReturningPopupViewModel<TReturn>, new()
 		{
 			TPage page = new();
 			TViewModel viewModel = new();
@@ -65,7 +65,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public async Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : ReturningPopupViewModel<TReturn>
+		public async Task<TReturn?> PushAsync<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : ReturningPopupViewModel<TReturn>
 		{
 			page.ViewModel = viewModel;
 			this.viewModelStack.Push(viewModel);
@@ -74,7 +74,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public async Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TPage page) where TPage : BasePopup
+		public async Task<TReturn?> PushAsync<TPage, TViewModel, TReturn>(TPage page) where TPage : BasePopup
 			where TViewModel : ReturningPopupViewModel<TReturn>, new()
 		{
 			TViewModel viewModel = new();
@@ -85,7 +85,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public async Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TViewModel viewModel) where TPage : BasePopup, new() where TViewModel : ReturningPopupViewModel<TReturn>
+		public async Task<TReturn?> PushAsync<TPage, TViewModel, TReturn>(TViewModel viewModel) where TPage : BasePopup, new() where TViewModel : ReturningPopupViewModel<TReturn>
 		{
 			TPage page = new();
 			page.ViewModel = viewModel;
@@ -95,7 +95,7 @@ namespace NeuroAccessMaui.Services.Popup
 		}
 
 		/// <inheritdoc/>
-		public async Task PopPopupAsync()
+		public async Task PopAsync()
 		{
 			if (this.viewModelStack.Count == 0)
 				return;

--- a/NeuroAccessMaui/Services/Popup/PopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/PopupService.cs
@@ -1,0 +1,93 @@
+﻿using Mopups.Services;
+using NeuroAccessMaui.UI.Popups;
+using Waher.Runtime.Inventory;
+
+namespace NeuroAccessMaui.Services.Popup
+{
+	[Singleton]
+	public class PopupService : IPopupService
+	{
+		/// <inheritdoc/>
+		public Task PushPopup<TPage, TViewModel>() where TPage : BasePopup, new() where TViewModel : BasePopupViewModel, new()
+		{
+			TPage page = new();
+			TViewModel viewModel = new();
+			page.ViewModel = viewModel;
+
+			return MopupService.Instance.PushAsync(page);
+		}
+
+		/// <inheritdoc/>
+		public Task PushPopup<TPage, TViewModel>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : BasePopupViewModel
+		{
+			page.ViewModel = viewModel;
+			return MopupService.Instance.PushAsync(page);
+		}
+
+		/// <inheritdoc/>
+		public Task PushPopup<TPage, TViewModel>(TPage page) where TPage : BasePopup where TViewModel : BasePopupViewModel, new()
+		{
+			TViewModel viewModel = new();
+			page.ViewModel = viewModel;
+			return MopupService.Instance.PushAsync(page);
+		}
+
+		/// <inheritdoc/>
+		public Task PushPopup<TPage, TViewModel>(TViewModel viewModel) where TPage : BasePopup, new() where TViewModel : BasePopupViewModel
+		{
+			TPage page = new();
+			page.ViewModel = viewModel;
+			return MopupService.Instance.PushAsync(page);
+		}
+
+		/// <inheritdoc/>
+		public Task PushPopup<TPage>() where TPage : BasePopup, new()
+		{
+			TPage page = new();
+			return MopupService.Instance.PushAsync(page);
+		}
+
+		/// <inheritdoc/>
+		public async Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>() where TPage : BasePopup, new() where TViewModel : ReturningPopupViewModel<TReturn>, new()
+		{
+			TPage page = new();
+			TViewModel viewModel = new();
+			page.ViewModel = viewModel;
+
+			await MopupService.Instance.PushAsync(page);
+			return await viewModel.Result;
+		}
+
+		/// <inheritdoc/>
+		public async Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : ReturningPopupViewModel<TReturn>
+		{
+			page.ViewModel = viewModel;
+			await MopupService.Instance.PushAsync(page);
+			return await viewModel.Result;
+		}
+
+		/// <inheritdoc/>
+		public async Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TPage page) where TPage : BasePopup
+			where TViewModel : ReturningPopupViewModel<TReturn>, new()
+		{
+			TViewModel viewModel = new();
+			page.ViewModel = viewModel;
+			await MopupService.Instance.PushAsync(page);
+			return await viewModel.Result;
+		}
+
+		/// <inheritdoc/>
+		public async Task<TReturn?> PushPopup<TPage, TViewModel, TReturn>(TViewModel viewModel) where TPage : BasePopup, new() where TViewModel : ReturningPopupViewModel<TReturn>
+		{
+			TPage page = new();
+			page.ViewModel = viewModel;
+			await MopupService.Instance.PushAsync(page);
+			return await viewModel.Result;
+		}
+
+		public async Task PopPopup()
+		{
+			await MopupService.Instance.PopAsync();
+		}
+	}
+}

--- a/NeuroAccessMaui/Services/Popup/PopupService.cs
+++ b/NeuroAccessMaui/Services/Popup/PopupService.cs
@@ -7,13 +7,15 @@ namespace NeuroAccessMaui.Services.Popup
 	[Singleton]
 	public class PopupService : IPopupService
 	{
+		protected readonly Stack<BasePopupViewModel?> viewModelStack = new();
+
 		/// <inheritdoc/>
 		public Task PushPopupAsync<TPage, TViewModel>() where TPage : BasePopup, new() where TViewModel : BasePopupViewModel, new()
 		{
 			TPage page = new();
 			TViewModel viewModel = new();
 			page.ViewModel = viewModel;
-
+			this.viewModelStack.Push(viewModel);
 			return MopupService.Instance.PushAsync(page);
 		}
 
@@ -21,6 +23,7 @@ namespace NeuroAccessMaui.Services.Popup
 		public Task PushPopupAsync<TPage, TViewModel>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : BasePopupViewModel
 		{
 			page.ViewModel = viewModel;
+			this.viewModelStack.Push(viewModel);
 			return MopupService.Instance.PushAsync(page);
 		}
 
@@ -29,6 +32,7 @@ namespace NeuroAccessMaui.Services.Popup
 		{
 			TViewModel viewModel = new();
 			page.ViewModel = viewModel;
+			this.viewModelStack.Push(viewModel);
 			return MopupService.Instance.PushAsync(page);
 		}
 
@@ -37,6 +41,7 @@ namespace NeuroAccessMaui.Services.Popup
 		{
 			TPage page = new();
 			page.ViewModel = viewModel;
+			this.viewModelStack.Push(viewModel);
 			return MopupService.Instance.PushAsync(page);
 		}
 
@@ -44,6 +49,7 @@ namespace NeuroAccessMaui.Services.Popup
 		public Task PushPopupAsync<TPage>() where TPage : BasePopup, new()
 		{
 			TPage page = new();
+			this.viewModelStack.Push(null);
 			return MopupService.Instance.PushAsync(page);
 		}
 
@@ -53,7 +59,7 @@ namespace NeuroAccessMaui.Services.Popup
 			TPage page = new();
 			TViewModel viewModel = new();
 			page.ViewModel = viewModel;
-
+			this.viewModelStack.Push(viewModel);
 			await MopupService.Instance.PushAsync(page);
 			return await viewModel.Result;
 		}
@@ -62,6 +68,7 @@ namespace NeuroAccessMaui.Services.Popup
 		public async Task<TReturn?> PushPopupAsync<TPage, TViewModel, TReturn>(TPage page, TViewModel viewModel) where TPage : BasePopup where TViewModel : ReturningPopupViewModel<TReturn>
 		{
 			page.ViewModel = viewModel;
+			this.viewModelStack.Push(viewModel);
 			await MopupService.Instance.PushAsync(page);
 			return await viewModel.Result;
 		}
@@ -72,6 +79,7 @@ namespace NeuroAccessMaui.Services.Popup
 		{
 			TViewModel viewModel = new();
 			page.ViewModel = viewModel;
+			this.viewModelStack.Push(viewModel);
 			await MopupService.Instance.PushAsync(page);
 			return await viewModel.Result;
 		}
@@ -81,12 +89,18 @@ namespace NeuroAccessMaui.Services.Popup
 		{
 			TPage page = new();
 			page.ViewModel = viewModel;
+			this.viewModelStack.Push(viewModel);
 			await MopupService.Instance.PushAsync(page);
 			return await viewModel.Result;
 		}
 
+		/// <inheritdoc/>
 		public async Task PopPopupAsync()
 		{
+			if (this.viewModelStack.Count == 0)
+				return;
+			BasePopupViewModel? vm = this.viewModelStack.Pop();
+			vm?.OnPop();
 			await MopupService.Instance.PopAsync();
 		}
 	}

--- a/NeuroAccessMaui/Services/Screenshot/IScreenshotService.cs
+++ b/NeuroAccessMaui/Services/Screenshot/IScreenshotService.cs
@@ -1,0 +1,14 @@
+﻿using NeuroAccessMaui.UI.Popups;
+using Waher.Runtime.Inventory;
+
+namespace NeuroAccessMaui.Services.Screenshot
+{
+	[DefaultImplementation(typeof(ScreenshotService))]
+	public interface IScreenshotService
+	{
+		Task<ImageSource?> TakeScreenshotAsync();
+
+		Task<ImageSource?> TakeBlurredScreenshotAsync();
+
+	}
+}

--- a/NeuroAccessMaui/Services/Screenshot/ScreenshotService.cs
+++ b/NeuroAccessMaui/Services/Screenshot/ScreenshotService.cs
@@ -1,0 +1,73 @@
+﻿using IdApp.Cv;
+using IdApp.Cv.Channels;
+using IdApp.Cv.ColorModels;
+using Microsoft.Maui.Animations;
+using SkiaSharp;
+using Waher.Runtime.Inventory;
+namespace NeuroAccessMaui.Services.Screenshot
+{
+	[Singleton]
+	public class ScreenshotService : IScreenshotService
+	{
+		public async Task<ImageSource?> TakeBlurredScreenshotAsync()
+		{
+			try
+			{
+
+				IScreenshotResult? result = await Microsoft.Maui.Media.Screenshot.CaptureAsync();
+				if (result is null)
+					return null;
+				//Read screenshot
+				using (Stream pngStream = await result.OpenReadAsync(ScreenshotFormat.Png, 20))
+				{
+					// Original SKBitmap from PNG stream
+					SKBitmap originalBitmap = SKBitmap.FromImage(SKImage.FromEncodedData(pngStream));
+
+					// Desired width and height for the downscaled image
+					int desiredWidth = originalBitmap.Width / 4;   //Reduce the width by a quarter
+					int desiredHeight = originalBitmap.Height / 4; //Reduce the height by a quarter
+
+					// Create an SKImageInfo with the desired width, height, and color type of the original
+					SKImageInfo resizedInfo = new SKImageInfo(desiredWidth, desiredHeight, SKColorType.Gray8);
+
+					// Create a new SKBitmap for the downscaled image
+					SKBitmap resizedBitmap = originalBitmap.Resize(resizedInfo, SKFilterQuality.Medium);
+
+					//Blur image
+					IMatrix rezisedMatrix = IdApp.Cv.Bitmaps.FromBitmap(resizedBitmap);
+					IMatrix greyChannelMatrix = rezisedMatrix.GrayScale(); 
+					IMatrix newMatrix = IdApp.Cv.Transformations.Convolutions.ConvolutionOperations.GaussianBlur(greyChannelMatrix, 12, 3.5f);
+
+					// Continue with the blurring and encoding to PNG as before
+					byte[] blurred = IdApp.Cv.Bitmaps.EncodeAsPng(newMatrix);
+					return ImageSource.FromStream(() => new MemoryStream(blurred));
+				}
+			}
+			catch (Exception e)
+			{
+				ServiceRef.LogService.LogException(e);
+				return null;
+			}
+		}
+
+		public async Task<ImageSource?> TakeScreenshotAsync()
+		{
+			IScreenshotResult? result = await Microsoft.Maui.Media.Screenshot.CaptureAsync();
+			if (result is not null)
+			{
+				// Read the stream into a memory stream or byte array
+				using (Stream stream = await result.OpenReadAsync())
+				{
+					MemoryStream memoryStream = new MemoryStream();
+					await stream.CopyToAsync(memoryStream);
+					byte[] bytes = memoryStream.ToArray();
+
+					// Return a new MemoryStream based on the byte array for each invocation
+					return ImageSource.FromStream(() => new MemoryStream(bytes));
+				}
+			}
+			return null;
+		}
+	}
+}
+

--- a/NeuroAccessMaui/Services/ServiceRef.cs
+++ b/NeuroAccessMaui/Services/ServiceRef.cs
@@ -11,6 +11,7 @@ using NeuroAccessMaui.Services.Nfc;
 using NeuroAccessMaui.Services.Notification;
 using NeuroAccessMaui.Services.Popup;
 using NeuroAccessMaui.Services.Push;
+using NeuroAccessMaui.Services.Screenshot;
 using NeuroAccessMaui.Services.Settings;
 using NeuroAccessMaui.Services.Storage;
 using NeuroAccessMaui.Services.Tag;
@@ -47,6 +48,7 @@ namespace NeuroAccessMaui.Services
 		private static IPlatformSpecific? platformSpecific;
 		private static IBarcodeReader? barcodeReader;
 		private static IPopupService? popupService;
+		private static IScreenshotService? screenshotService;
 
 		/// <summary>
 		/// The dispatcher to use for alerts and accessing the main thread.
@@ -286,6 +288,18 @@ namespace NeuroAccessMaui.Services
 			{
 				popupService ??= App.Instantiate<IPopupService>();
 				return popupService;
+			}
+		}
+
+		/// <summary>
+		/// Screenshot service
+		/// </summary>
+		public static IScreenshotService ScreenshotService
+		{
+			get
+			{
+				screenshotService ??= App.Instantiate<IScreenshotService>();
+				return screenshotService;
 			}
 		}
 	}

--- a/NeuroAccessMaui/Services/ServiceRef.cs
+++ b/NeuroAccessMaui/Services/ServiceRef.cs
@@ -9,6 +9,7 @@ using NeuroAccessMaui.Services.Navigation;
 using NeuroAccessMaui.Services.Network;
 using NeuroAccessMaui.Services.Nfc;
 using NeuroAccessMaui.Services.Notification;
+using NeuroAccessMaui.Services.Popup;
 using NeuroAccessMaui.Services.Push;
 using NeuroAccessMaui.Services.Settings;
 using NeuroAccessMaui.Services.Storage;
@@ -45,6 +46,7 @@ namespace NeuroAccessMaui.Services
 		private static IStringLocalizer? localizer;
 		private static IPlatformSpecific? platformSpecific;
 		private static IBarcodeReader? barcodeReader;
+		private static IPopupService? popupService;
 
 		/// <summary>
 		/// The dispatcher to use for alerts and accessing the main thread.
@@ -272,6 +274,18 @@ namespace NeuroAccessMaui.Services
 			{
 				barcodeReader ??= ServiceHelper.GetService<IBarcodeReader>();
 				return barcodeReader;
+			}
+		}
+
+		/// <summary>
+		/// Popup service
+		/// </summary>
+		public static IPopupService PopupService
+		{
+			get
+			{
+				popupService ??= App.Instantiate<IPopupService>();
+				return popupService;
 			}
 		}
 	}

--- a/NeuroAccessMaui/UI/PageAppExtension.cs
+++ b/NeuroAccessMaui/UI/PageAppExtension.cs
@@ -157,7 +157,6 @@ namespace NeuroAccessMaui.UI
 
 			// Popups
 			Builder.Services.AddTransient<ImageView, ImageViewModel>();
-			Builder.Services.AddTransient<CheckPinPopup, CheckPinViewModel>();
 			Builder.Services.AddTransient<AddTextNotePopup, AddTextNoteViewModel>();
 
 			// Xmpp

--- a/NeuroAccessMaui/UI/Pages/Applications/ApplyId/ApplyIdViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Applications/ApplyId/ApplyIdViewModel.cs
@@ -45,8 +45,6 @@ namespace NeuroAccessMaui.UI.Pages.Applications.ApplyId
 
 		protected override async Task OnInitialize()
 		{
-			await ServiceRef.PopupService.PushPopupAsync<TestPopup, TestPopupViewModel>();
-
 			this.ApplicationId = null;
 
 			if (ServiceRef.TagProfile.IdentityApplication is not null)

--- a/NeuroAccessMaui/UI/Pages/Applications/ApplyId/ApplyIdViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Applications/ApplyId/ApplyIdViewModel.cs
@@ -45,7 +45,7 @@ namespace NeuroAccessMaui.UI.Pages.Applications.ApplyId
 
 		protected override async Task OnInitialize()
 		{
-			await ServiceRef.PopupService.PushPopup<TestPopup, TestPopupViewModel>();
+			await ServiceRef.PopupService.PushPopupAsync<TestPopup, TestPopupViewModel>();
 
 			this.ApplicationId = null;
 

--- a/NeuroAccessMaui/UI/Pages/Applications/ApplyId/ApplyIdViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Applications/ApplyId/ApplyIdViewModel.cs
@@ -11,6 +11,7 @@ using NeuroAccessMaui.Services.UI.Photos;
 using NeuroAccessMaui.UI.Pages.Identity.ViewIdentity;
 using NeuroAccessMaui.UI.Pages.Registration;
 using NeuroAccessMaui.UI.Pages.Wallet.ServiceProviders;
+using NeuroAccessMaui.UI.Popups;
 using SkiaSharp;
 using Waher.Content;
 using Waher.Networking.XMPP;
@@ -44,6 +45,8 @@ namespace NeuroAccessMaui.UI.Pages.Applications.ApplyId
 
 		protected override async Task OnInitialize()
 		{
+			await ServiceRef.PopupService.PushPopup<TestPopup, TestPopupViewModel>();
+
 			this.ApplicationId = null;
 
 			if (ServiceRef.TagProfile.IdentityApplication is not null)

--- a/NeuroAccessMaui/UI/Pages/Applications/ApplyId/ApplyIdViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Applications/ApplyId/ApplyIdViewModel.cs
@@ -867,7 +867,6 @@ namespace NeuroAccessMaui.UI.Pages.Applications.ApplyId
 					}
 				}
 
-				/// TODO: Check if this code below is still needed
 				if (FallbackOriginal)
 				{
 					byte[] Bin = File.ReadAllBytes(FilePath);

--- a/NeuroAccessMaui/UI/Pages/Main/Settings/SettingsViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Main/Settings/SettingsViewModel.cs
@@ -6,7 +6,7 @@ using NeuroAccessMaui.Services;
 using NeuroAccessMaui.Services.Tag;
 using NeuroAccessMaui.UI.Pages.Identity.TransferIdentity;
 using NeuroAccessMaui.UI.Pages.Main.ChangePin;
-using NeuroAccessMaui.UI.Popups;
+using NeuroAccessMaui.UI.Popups.Settings;
 using System.ComponentModel;
 using System.Security.Cryptography;
 using System.Text;
@@ -478,8 +478,7 @@ namespace NeuroAccessMaui.UI.Pages.Main.Settings
 		[RelayCommand]
 		private static async Task ChangeLanguage()
 		{
-			SelectLanguagePopup Page = new();
-			await MopupService.Instance.PushAsync(Page);
+			await ServiceRef.PopupService.PushAsync<SelectLanguagePopup>();
 		}
 
 		#endregion

--- a/NeuroAccessMaui/UI/Pages/Registration/RegistrationViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Registration/RegistrationViewModel.cs
@@ -6,7 +6,7 @@ using Mopups.Services;
 using NeuroAccessMaui.Services;
 using NeuroAccessMaui.Services.Localization;
 using NeuroAccessMaui.Services.Tag;
-using NeuroAccessMaui.UI.Popups;
+using NeuroAccessMaui.UI.Popups.Settings;
 
 namespace NeuroAccessMaui.UI.Pages.Registration
 {
@@ -139,8 +139,7 @@ namespace NeuroAccessMaui.UI.Pages.Registration
 		[RelayCommand]
 		private static async Task ChangeLanguage()
 		{
-			SelectLanguagePopup Page = new();
-			await MopupService.Instance.PushAsync(Page);
+			await ServiceRef.PopupService.PushAsync<SelectLanguagePopup>();
 		}
 	}
 }

--- a/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
@@ -1,4 +1,8 @@
-﻿namespace NeuroAccessMaui.UI.Popups
+﻿using Mopups.Pages;
+using Mopups.PreBaked.PopupPages.SingleResponse;
+using Waher.Networking.XMPP.Contracts.Search;
+
+namespace NeuroAccessMaui.UI.Popups
 {
 	/// <summary>
 	/// Creates a base popup
@@ -8,6 +12,12 @@
 		public virtual double ViewWidthRequest => (DeviceDisplay.MainDisplayInfo.Width / DeviceDisplay.MainDisplayInfo.Density) * (7.0 / 8.0);
 		public virtual double MaximumViewHeightRequest => (DeviceDisplay.MainDisplayInfo.Height / DeviceDisplay.MainDisplayInfo.Density) * (3.0 / 4.0);
 
+		public BasePopupViewModel ViewModel
+		{
+			get => this.BindingContext as BasePopupViewModel ?? throw new InvalidOperationException("BindingContext must be of type BasePopupViewModel");
+			set => this.BindingContext = value ?? throw new ArgumentNullException(nameof(value), @"ViewModel cannot be null");
+		}
+
 		protected BasePopup(ImageSource? Background)
 		{
 			this.InitializeComponent();
@@ -16,6 +26,17 @@
 				this.BackgroundImageSource = Background;
 			else
 				this.BackgroundColor = Color.FromInt(0x20000000);
+		}
+
+		protected override bool OnBackButtonPressed()
+		{
+			this.ViewModel.Close();
+			return base.OnBackButtonPressed();
+		}
+		protected override bool OnBackgroundClicked()
+		{
+			this.ViewModel.Close();
+			return base.OnBackgroundClicked();
 		}
 	}
 }

--- a/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
@@ -36,18 +36,18 @@ namespace NeuroAccessMaui.UI.Popups
 
 		protected override bool OnBackButtonPressed()
 		{
-			this.ViewModel?.Close();
+			this.ViewModel?.OnPop();
 			return base.OnBackButtonPressed();
 		}
 		protected override bool OnBackgroundClicked()
 		{
-			this.ViewModel?.Close();
+			this.ViewModel?.OnPop();
 			return base.OnBackgroundClicked();
 		}
 
 		protected override void OnDisappearing()
 		{
-			this.ViewModel?.Close();
+			this.ViewModel?.OnPop();
 			base.OnDisappearing();
 		}
 	}

--- a/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using Mopups.Pages;
 using Mopups.PreBaked.PopupPages.SingleResponse;
+using NeuroAccessMaui.Services;
 using Waher.Networking.XMPP.Contracts.Search;
 
 namespace NeuroAccessMaui.UI.Popups
@@ -12,9 +13,9 @@ namespace NeuroAccessMaui.UI.Popups
 		public virtual double ViewWidthRequest => (DeviceDisplay.MainDisplayInfo.Width / DeviceDisplay.MainDisplayInfo.Density) * (7.0 / 8.0);
 		public virtual double MaximumViewHeightRequest => (DeviceDisplay.MainDisplayInfo.Height / DeviceDisplay.MainDisplayInfo.Density) * (3.0 / 4.0);
 
-		public BasePopupViewModel ViewModel
+		public BasePopupViewModel? ViewModel
 		{
-			get => this.BindingContext as BasePopupViewModel ?? throw new InvalidOperationException("BindingContext must be of type BasePopupViewModel");
+			get => this.BindingContext as BasePopupViewModel;
 			set => this.BindingContext = value ?? throw new ArgumentNullException(nameof(value), @"ViewModel cannot be null");
 		}
 
@@ -28,15 +29,26 @@ namespace NeuroAccessMaui.UI.Popups
 				this.BackgroundColor = Color.FromInt(0x20000000);
 		}
 
+		protected void ClosePopup()
+		{
+			ServiceRef.PopupService.PopPopup();
+		}
+
 		protected override bool OnBackButtonPressed()
 		{
-			this.ViewModel.Close();
+			this.ViewModel?.Close();
 			return base.OnBackButtonPressed();
 		}
 		protected override bool OnBackgroundClicked()
 		{
-			this.ViewModel.Close();
+			this.ViewModel?.Close();
 			return base.OnBackgroundClicked();
+		}
+
+		protected override void OnDisappearing()
+		{
+			this.ViewModel?.Close();
+			base.OnDisappearing();
 		}
 	}
 }

--- a/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
@@ -16,7 +16,7 @@ namespace NeuroAccessMaui.UI.Popups
 		public BasePopupViewModel? ViewModel
 		{
 			get => this.BindingContext as BasePopupViewModel;
-			set => this.BindingContext = value ?? throw new ArgumentNullException(nameof(value), @"ViewModel cannot be null");
+			set => this.BindingContext = value;
 		}
 
 		protected BasePopup(ImageSource? Background)

--- a/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
@@ -31,7 +31,7 @@ namespace NeuroAccessMaui.UI.Popups
 
 		protected void ClosePopup()
 		{
-			ServiceRef.PopupService.PopPopup();
+			ServiceRef.PopupService.PopPopupAsync();
 		}
 
 		protected override bool OnBackButtonPressed()

--- a/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
@@ -34,21 +34,26 @@ namespace NeuroAccessMaui.UI.Popups
 			ServiceRef.PopupService.PopPopupAsync();
 		}
 
-		protected override bool OnBackButtonPressed()
+		protected override void OnAppearing()
 		{
-			this.ViewModel?.OnPop();
-			return base.OnBackButtonPressed();
-		}
-		protected override bool OnBackgroundClicked()
-		{
-			this.ViewModel?.OnPop();
-			return base.OnBackgroundClicked();
+			base.OnAppearing();
 		}
 
 		protected override void OnDisappearing()
 		{
-			this.ViewModel?.OnPop();
 			base.OnDisappearing();
+		}
+
+		protected override bool OnBackButtonPressed()
+		{
+			ServiceRef.PopupService.PopPopupAsync();
+			return true;
+		}
+
+		protected override bool OnBackgroundClicked()
+		{
+			ServiceRef.PopupService.PopPopupAsync();
+			return true;
 		}
 	}
 }

--- a/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Mopups.Pages;
+﻿using System.Diagnostics;
+using Mopups.Pages;
 using Mopups.PreBaked.PopupPages.SingleResponse;
 using NeuroAccessMaui.Services;
 using Waher.Networking.XMPP.Contracts.Search;
@@ -12,7 +13,7 @@ namespace NeuroAccessMaui.UI.Popups
 	{
 		public virtual double ViewWidthRequest => (DeviceDisplay.MainDisplayInfo.Width / DeviceDisplay.MainDisplayInfo.Density) * (7.0 / 8.0);
 		public virtual double MaximumViewHeightRequest => (DeviceDisplay.MainDisplayInfo.Height / DeviceDisplay.MainDisplayInfo.Density) * (3.0 / 4.0);
-
+		private Stream? backgroundStream = null;
 		public BasePopupViewModel? ViewModel
 		{
 			get => this.BindingContext as BasePopupViewModel;
@@ -23,10 +24,15 @@ namespace NeuroAccessMaui.UI.Popups
 		{
 			this.InitializeComponent();
 
-			if (Background is not null)
-				this.BackgroundImageSource = Background;
-			else
-				this.BackgroundColor = Color.FromInt(0x20000000);
+			//this.LoadScreenshotAsync();
+
+		}
+
+		private async void LoadScreenshotAsync()
+		{
+				this.BackgroundImageSource = await ServiceRef.ScreenshotService.TakeBlurredScreenshotAsync();
+				if(this.backgroundStream is null)
+					this.BackgroundColor = Color.FromInt(0x20000000);
 		}
 
 		protected void ClosePopup()
@@ -36,6 +42,7 @@ namespace NeuroAccessMaui.UI.Popups
 
 		protected override void OnAppearing()
 		{
+			this.LoadScreenshotAsync();
 			base.OnAppearing();
 		}
 

--- a/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
@@ -31,7 +31,7 @@ namespace NeuroAccessMaui.UI.Popups
 
 		protected void ClosePopup()
 		{
-			ServiceRef.PopupService.PopPopupAsync();
+			ServiceRef.PopupService.PopAsync();
 		}
 
 		protected override void OnAppearing()
@@ -46,13 +46,13 @@ namespace NeuroAccessMaui.UI.Popups
 
 		protected override bool OnBackButtonPressed()
 		{
-			ServiceRef.PopupService.PopPopupAsync();
+			ServiceRef.PopupService.PopAsync();
 			return true;
 		}
 
 		protected override bool OnBackgroundClicked()
 		{
-			ServiceRef.PopupService.PopPopupAsync();
+			ServiceRef.PopupService.PopAsync();
 			return true;
 		}
 	}

--- a/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopup.xaml.cs
@@ -13,54 +13,72 @@ namespace NeuroAccessMaui.UI.Popups
 	{
 		public virtual double ViewWidthRequest => (DeviceDisplay.MainDisplayInfo.Width / DeviceDisplay.MainDisplayInfo.Density) * (7.0 / 8.0);
 		public virtual double MaximumViewHeightRequest => (DeviceDisplay.MainDisplayInfo.Height / DeviceDisplay.MainDisplayInfo.Density) * (3.0 / 4.0);
-		private Stream? backgroundStream = null;
+
+		/// <summary>
+		/// If true, the background will be a blurred screenshot of the current page
+		/// If false the background will be fully transparent and can be modified by derived classes
+		/// </summary>
+		protected bool useDefaultBackground;
+
+		/// <summary>
+		/// Returns the current BindingContext as a BasePopupViewModel
+		/// Returns null if failed
+		/// </summary>
 		public BasePopupViewModel? ViewModel
 		{
 			get => this.BindingContext as BasePopupViewModel;
 			set => this.BindingContext = value;
 		}
 
-		protected BasePopup(ImageSource? Background)
+		protected BasePopup(bool useDefaultBackground = true)
 		{
+			this.useDefaultBackground = useDefaultBackground;
 			this.InitializeComponent();
-
-			//this.LoadScreenshotAsync();
-
 		}
 
-		private async void LoadScreenshotAsync()
+		/// <summary>
+		/// A shortcut for <see cref="NeuroAccessMaui.Services.Popup.IPopupService.PopAsync"/>
+		/// </summary>
+		protected async void PopAsync()
 		{
-				this.BackgroundImageSource = await ServiceRef.ScreenshotService.TakeBlurredScreenshotAsync();
-				if(this.backgroundStream is null)
-					this.BackgroundColor = Color.FromInt(0x20000000);
-		}
-
-		protected void ClosePopup()
-		{
-			ServiceRef.PopupService.PopAsync();
+			await ServiceRef.PopupService.PopAsync();
 		}
 
 		protected override void OnAppearing()
 		{
-			this.LoadScreenshotAsync();
+			if (this.useDefaultBackground)
+				this.LoadScreenshotAsync();
 			base.OnAppearing();
 		}
 
-		protected override void OnDisappearing()
-		{
-			base.OnDisappearing();
-		}
-
+		/// <summary>
+		/// Called when the back button on the client is pressed
+		/// </summary>
+		/// <remarks>All derived methods should return base.OnBackgroundClicked()</remarks>
+		/// <returns>True</returns>
 		protected override bool OnBackButtonPressed()
 		{
 			ServiceRef.PopupService.PopAsync();
 			return true;
 		}
 
+		/// <summary>
+		/// Called when the background is pressed.
+		/// </summary>
+		/// <remarks>All derived methods should return base.OnBackgroundClicked()</remarks>
+		/// <returns>True</returns>
 		protected override bool OnBackgroundClicked()
 		{
 			ServiceRef.PopupService.PopAsync();
 			return true;
+		}
+
+		/// <summary>
+		/// Sets the popup background to a blurred screenshot of the current page
+		/// </summary>
+		private async void LoadScreenshotAsync()
+		{
+			this.BackgroundImageSource = await ServiceRef.ScreenshotService.TakeBlurredScreenshotAsync();
 		}
 	}
 }

--- a/NeuroAccessMaui/UI/Popups/BasePopupViewModel.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopupViewModel.cs
@@ -9,7 +9,7 @@ namespace NeuroAccessMaui.UI.Popups
 {
 	public class BasePopupViewModel : BaseViewModel
 	{
-		public virtual void Close()
+		public virtual void OnPop()
 		{
 		}
 	}

--- a/NeuroAccessMaui/UI/Popups/BasePopupViewModel.cs
+++ b/NeuroAccessMaui/UI/Popups/BasePopupViewModel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NeuroAccessMaui.UI.Pages;
+
+namespace NeuroAccessMaui.UI.Popups
+{
+	public class BasePopupViewModel : BaseViewModel
+	{
+		public virtual void Close()
+		{
+		}
+	}
+}

--- a/NeuroAccessMaui/UI/Popups/Pin/CheckPinPopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/Pin/CheckPinPopup.xaml.cs
@@ -1,35 +1,21 @@
 ﻿namespace NeuroAccessMaui.UI.Popups.Pin
 {
 	/// <summary>
-	/// Page letting the user enter a PIN to be verified with the PIN defined by the user earlier.
+	/// A Popup letting the user enter a PIN to be verified with the PIN defined by the user earlier.
 	/// </summary>
 	public partial class CheckPinPopup
 	{
-		private readonly CheckPinViewModel viewModel;
 
-		/// <summary>
-		/// Page letting the user enter a PIN to be verified with the PIN defined by the user earlier.
-		/// </summary>
-		/// <param name="ViewModel">View model.</param>
-		/// <param name="Background">Optional background.</param>
-		public CheckPinPopup(CheckPinViewModel ViewModel, ImageSource? Background = null)
-			: base(Background)
+		public CheckPinPopup()
+			: base(null)
 		{
 			this.InitializeComponent();
-			this.BindingContext = this.viewModel = ViewModel;
 		}
 
 		protected override void OnAppearing()
 		{
 			this.PinEntry.Focus();
 			base.OnAppearing();
-		}
-
-		/// <inheritdoc/>
-		protected override void OnDisappearing()
-		{
-			this.viewModel.Close();
-			base.OnDisappearing();
 		}
 	}
 }

--- a/NeuroAccessMaui/UI/Popups/Pin/CheckPinPopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/Pin/CheckPinPopup.xaml.cs
@@ -5,9 +5,7 @@
 	/// </summary>
 	public partial class CheckPinPopup
 	{
-
 		public CheckPinPopup()
-			: base(null)
 		{
 			this.InitializeComponent();
 		}

--- a/NeuroAccessMaui/UI/Popups/Pin/CheckPinViewModel.cs
+++ b/NeuroAccessMaui/UI/Popups/Pin/CheckPinViewModel.cs
@@ -10,22 +10,8 @@ namespace NeuroAccessMaui.UI.Popups.Pin
 	/// <summary>
 	/// View model for page letting the user enter a PIN to be verified with the PIN defined by the user earlier.
 	/// </summary>
-	public partial class CheckPinViewModel : BaseViewModel
+	public partial class CheckPinViewModel : ReturningPopupViewModel<string>
 	{
-		private readonly TaskCompletionSource<string?> result = new();
-
-		/// <summary>
-		/// View model for page letting the user enter a PIN to be verified with the PIN defined by the user earlier.
-		/// </summary>
-		public CheckPinViewModel()
-			: base()
-		{
-		}
-
-		/// <summary>
-		/// Result will be provided here. If dialog is cancelled, null is returned.
-		/// </summary>
-		public Task<string?> Result => this.result.Task;
 
 		/// <summary>
 		/// PIN text entry
@@ -52,7 +38,7 @@ namespace NeuroAccessMaui.UI.Popups.Pin
 				if (await App.CheckPinAndUnblockUser(Pin))
 				{
 					this.result.TrySetResult(Pin);
-					await MopupService.Instance.PopAsync();
+					await ServiceRef.PopupService.PopAsync();
 				}
 				else
 				{
@@ -77,15 +63,7 @@ namespace NeuroAccessMaui.UI.Popups.Pin
 		private async Task Cancel()
 		{
 			this.result.TrySetResult(null);
-			await MopupService.Instance.PopAsync();
-		}
-
-		/// <summary>
-		/// Closes
-		/// </summary>
-		internal void Close()
-		{
-			this.result.TrySetResult(null);
+			await ServiceRef.PopupService.PopAsync();
 		}
 	}
 }

--- a/NeuroAccessMaui/UI/Popups/ReturningPopupViewModel.cs
+++ b/NeuroAccessMaui/UI/Popups/ReturningPopupViewModel.cs
@@ -16,7 +16,7 @@ namespace NeuroAccessMaui.UI.Popups
 		{
 			if (!this.Result.IsCompleted)
 			{
-				this.result.TrySetResult(default);
+				this.result.TrySetResult(default(TReturn?));
 			}
 		}
 	}

--- a/NeuroAccessMaui/UI/Popups/ReturningPopupViewModel.cs
+++ b/NeuroAccessMaui/UI/Popups/ReturningPopupViewModel.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace NeuroAccessMaui.UI.Popups
+{
+	public class ReturningPopupViewModel<TReturn> : BasePopupViewModel
+	{
+		protected readonly TaskCompletionSource<TReturn?> result = new();
+
+		public Task<TReturn?> Result => this.result.Task;
+
+		public override void Close()
+		{
+			if (!this.Result.IsCompleted)
+			{
+				this.result.TrySetResult(default);
+			}
+		}
+	}
+}

--- a/NeuroAccessMaui/UI/Popups/ReturningPopupViewModel.cs
+++ b/NeuroAccessMaui/UI/Popups/ReturningPopupViewModel.cs
@@ -12,7 +12,7 @@ namespace NeuroAccessMaui.UI.Popups
 
 		public Task<TReturn?> Result => this.result.Task;
 
-		public override void Close()
+		public override void OnPop()
 		{
 			if (!this.Result.IsCompleted)
 			{

--- a/NeuroAccessMaui/UI/Popups/SelectPhoneCodePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/SelectPhoneCodePopup.xaml.cs
@@ -19,8 +19,7 @@ namespace NeuroAccessMaui.UI.Popups
 		/// </summary>
 		public static ISO_3166_Country[] Countries => ISO_3166_1.Countries;
 
-		public SelectPhoneCodePopup(ImageSource? Background = null)
-			: base(Background)
+		public SelectPhoneCodePopup()
 		{
 			this.InitializeComponent();
 			this.BindingContext = this;

--- a/NeuroAccessMaui/UI/Popups/Settings/SelectLanguagePopup.xaml
+++ b/NeuroAccessMaui/UI/Popups/Settings/SelectLanguagePopup.xaml
@@ -1,12 +1,13 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<viewmodel:BasePopup x:Class="NeuroAccessMaui.UI.Popups.SelectLanguagePopup"
-							x:DataType="viewmodel:SelectLanguagePopup"
+<?xml version="1.0" encoding="UTF-8" ?>
+<base:BasePopup		x:Class="NeuroAccessMaui.UI.Popups.Settings.SelectLanguagePopup"
+							x:DataType="viewModel:SelectLanguagePopup"
 							xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
 							xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 							xmlns:controls="clr-namespace:NeuroAccessMaui.UI.Controls"
 							xmlns:converters="clr-namespace:NeuroAccessMaui.UI.Converters"
 							xmlns:l="clr-namespace:NeuroAccessMaui.Services.Localization"
-							xmlns:viewmodel="clr-namespace:NeuroAccessMaui.UI.Popups"
+						   xmlns:viewModel="clr-namespace:NeuroAccessMaui.UI.Popups.Settings"
+							xmlns:base="clr-namespace:NeuroAccessMaui.UI.Popups"
 							xmlns:animations="clr-namespace:Mopups.Animations;assembly=Mopups"
 							xmlns:mopups="clr-namespace:Mopups.Pages;assembly=Mopups">
 
@@ -71,4 +72,4 @@
 			</ScrollView>
 		</Border>
 	</Grid>
-</viewmodel:BasePopup>
+</base:BasePopup>

--- a/NeuroAccessMaui/UI/Popups/Settings/SelectLanguagePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/Settings/SelectLanguagePopup.xaml.cs
@@ -10,7 +10,6 @@ namespace NeuroAccessMaui.UI.Popups.Settings
 		public List<LanguageInfo> Languages { get; } = new(App.SupportedLanguages);
 
 		public SelectLanguagePopup()
-			: base(null)
 		{
 			this.InitializeComponent();
 

--- a/NeuroAccessMaui/UI/Popups/Settings/SelectLanguagePopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/Settings/SelectLanguagePopup.xaml.cs
@@ -1,54 +1,22 @@
-﻿using CommunityToolkit.Mvvm.Input;
+using CommunityToolkit.Mvvm.Input;
+using NeuroAccessMaui.Services;
 using NeuroAccessMaui.Services.Localization;
 using System.Globalization;
-
-namespace NeuroAccessMaui.UI.Popups
+namespace NeuroAccessMaui.UI.Popups.Settings
 {
 	public partial class SelectLanguagePopup
 	{
-		/*
-		/// <summary>
-		/// Popup factory
-		/// </summary>
-		public static Task<SelectLanguagePopup> Create()
-		{
-			//SelectLanguageViewModel ViewModel = ServiceHelper.GetService<SelectLanguageViewModel>();
-			//return Task.FromResult(new SelectLanguagePopup(ViewModel));
-
-			return await MainThread.InvokeOnMainThreadAsync(async () => await
-			{
-				SelectLanguageViewModel ViewModel = new();
-
-				try
-				{
-					byte[] ScreenBitmap = await ServiceRef.PlatformSpecific.CaptureScreen(10);
-
-					ImageSource Background = ImageSource.FromStream(() => new MemoryStream(ScreenBitmap));
-					Page = new SelectLanguagePopup(ViewModel, Background);
-				}
-				catch (Exception ex)
-				{
-					ServiceRef.LogService.LogException(ex);
-					await ServiceRef.UiSerializer.DisplayException(ex);
-
-					Page = new SelectLanguagePopup(ViewModel, null);
-				}
-
-				return Page;
-			});
-		}
-		*/
 		public override double ViewWidthRequest => (DeviceDisplay.MainDisplayInfo.Width / DeviceDisplay.MainDisplayInfo.Density) * (3.0 / 4.0);
-
 		public List<LanguageInfo> Languages { get; } = new(App.SupportedLanguages);
 
-		public SelectLanguagePopup(ImageSource? Background = null)
-			: base(Background)
+		public SelectLanguagePopup()
+			: base(null)
 		{
 			this.InitializeComponent();
-			this.BindingContext = this;
 
+			this.BindingContext = this;
 			this.SelectLanguage(App.SelectedLanguage.Name);
+
 		}
 
 		[RelayCommand]
@@ -81,6 +49,7 @@ namespace NeuroAccessMaui.UI.Popups
 				Preferences.Set("user_selected_language", SelectedLanguage.TwoLetterISOLanguageName);
 				LocalizationManager.Current.CurrentCulture = SelectedLanguage;
 			}
+			ServiceRef.PopupService.PopAsync();
 		}
 	}
 }

--- a/NeuroAccessMaui/UI/Popups/ShowInfoPopup.xaml.cs
+++ b/NeuroAccessMaui/UI/Popups/ShowInfoPopup.xaml.cs
@@ -8,8 +8,7 @@ namespace NeuroAccessMaui.UI.Popups
 		public string InfoTitle { get; set; }
 		public string InfoText { get; set; }
 
-		public ShowInfoPopup(string InfoTitle, string InfoText, ImageSource? Background = null)
-			: base(Background)
+		public ShowInfoPopup(string InfoTitle, string InfoText)
 		{
 			this.InfoTitle = InfoTitle;
 			this.InfoText = InfoText;

--- a/NeuroAccessMaui/UI/Popups/Tokens/AddTextNote/AddTextNotePopup.cs
+++ b/NeuroAccessMaui/UI/Popups/Tokens/AddTextNote/AddTextNotePopup.cs
@@ -12,8 +12,7 @@ namespace NeuroAccessMaui.UI.Popups.Tokens.AddTextNote
 		/// </summary>
 		/// <param name="ViewModel">View model</param>
 		/// <param name="Background">Optional background</param>
-		public AddTextNotePopup(AddTextNoteViewModel ViewModel, ImageSource? Background = null)
-			: base(Background)
+		public AddTextNotePopup(AddTextNoteViewModel ViewModel)
 		{
 			this.InitializeComponent();
 			this.BindingContext = this.viewModel = ViewModel;

--- a/NeuroAccessMaui/UI/Popups/Xmpp/RemoveSubscription/RemoveSubscriptionPopup.cs
+++ b/NeuroAccessMaui/UI/Popups/Xmpp/RemoveSubscription/RemoveSubscriptionPopup.cs
@@ -11,9 +11,7 @@ namespace NeuroAccessMaui.UI.Popups.Xmpp.RemoveSubscription
 		/// Asks the user if it wants to remove an existing presence subscription request as well.
 		/// </summary>
 		/// <param name="ViewModel">View model</param>
-		/// <param name="Background">Optional background</param>
-		public RemoveSubscriptionPopup(RemoveSubscriptionViewModel ViewModel, ImageSource? Background = null)
-			: base(Background)
+		public RemoveSubscriptionPopup(RemoveSubscriptionViewModel ViewModel)
 		{
 			this.InitializeComponent();
 			this.BindingContext = this.viewModel = ViewModel;

--- a/NeuroAccessMaui/UI/Popups/Xmpp/ReportOrBlock/ReportOrBlockPopup.cs
+++ b/NeuroAccessMaui/UI/Popups/Xmpp/ReportOrBlock/ReportOrBlockPopup.cs
@@ -10,8 +10,7 @@ namespace NeuroAccessMaui.UI.Popups.Xmpp.ReportOrBlock
 		/// <summary>
 		/// Prompts the user for a response of a presence subscription request.
 		/// </summary>
-		public ReportOrBlockPopup(ReportOrBlockViewModel ViewModel, ImageSource? Background = null)
-			: base(Background)
+		public ReportOrBlockPopup(ReportOrBlockViewModel ViewModel)
 		{
 			this.InitializeComponent();
 			this.BindingContext = this.viewModel = ViewModel;

--- a/NeuroAccessMaui/UI/Popups/Xmpp/ReportType/ReportTypePopup.cs
+++ b/NeuroAccessMaui/UI/Popups/Xmpp/ReportType/ReportTypePopup.cs
@@ -1,17 +1,16 @@
 namespace NeuroAccessMaui.UI.Popups.Xmpp.ReportType
 {
-    /// <summary>
-    /// Prompts the user for a response of a presence subscription request.
-    /// </summary>
-    public partial class ReportTypePopup
-    {
+	/// <summary>
+	/// Prompts the user for a response of a presence subscription request.
+	/// </summary>
+	public partial class ReportTypePopup
+	{
 		private readonly ReportTypeViewModel viewModel;
 
 		/// <summary>
 		/// Prompts the user for a response of a presence subscription request.
 		/// </summary>
-		public ReportTypePopup(ReportTypeViewModel ViewModel, ImageSource? Background = null)
-			: base(Background)
+		public ReportTypePopup(ReportTypeViewModel ViewModel)
 		{
 			this.InitializeComponent();
 			this.BindingContext = this.viewModel = ViewModel;

--- a/NeuroAccessMaui/UI/Popups/Xmpp/SubscribeTo/SubscribeToPopup.cs
+++ b/NeuroAccessMaui/UI/Popups/Xmpp/SubscribeTo/SubscribeToPopup.cs
@@ -13,7 +13,6 @@ namespace NeuroAccessMaui.UI.Popups.Xmpp.SubscribeTo
 		/// <param name="ViewModel">View model</param>
 		/// <param name="Background">Optional background</param>
 		public SubscribeToPopup(SubscribeToViewModel ViewModel, ImageSource? Background = null)
-			: base(Background)
 		{
 			this.InitializeComponent();
 			this.BindingContext = this.viewModel = ViewModel;

--- a/NeuroAccessMaui/UI/Popups/Xmpp/SubscriptionRequest/SubscriptionRequestPopup.cs
+++ b/NeuroAccessMaui/UI/Popups/Xmpp/SubscriptionRequest/SubscriptionRequestPopup.cs
@@ -11,9 +11,7 @@ namespace NeuroAccessMaui.UI.Popups.Xmpp.SubscriptionRequest
 		/// Prompts the user for a response of a presence subscription request.
 		/// </summary>
 		/// <param name="ViewModel">View model</param>
-		/// <param name="Background">Optional background</param>
-		public SubscriptionRequestPopup(SubscriptionRequestViewModel ViewModel, ImageSource? Background = null)
-			: base(Background)
+		public SubscriptionRequestPopup(SubscriptionRequestViewModel ViewModel)
 		{
 			this.InitializeComponent();
 			this.BindingContext = this.viewModel = ViewModel;


### PR DESCRIPTION
## 2 new services
+ **ScreenshotService**
+ **PopupService**

## Mini docs
Popup pages/views should now inherit from BasePopup
While Popup ViewModels should inherit from either
BasePopupViewModel
ReturningPopupViewmodel (Popups that can return a value, ex. a bool, string etc)

The Viewmodels has a virtual method OnPop
which can be overriden for logic when popup closes

The ServiceRef.PopupService.PushAsync can be awaited if a ReturningPopupViewmodel is sent with it.

