### PR TITLE
Add CarouselView directly on viewID page instead of using popup

### DIFF
--- a/NeuroAccessMaui/UI/Pages/Identity/ViewIdentity/ViewIdentityPage.xaml
+++ b/NeuroAccessMaui/UI/Pages/Identity/ViewIdentity/ViewIdentityPage.xaml
@@ -32,15 +32,35 @@
 					<VerticalStackLayout>
 						<VerticalStackLayout Margin="{StaticResource LargeMargins}" Spacing="{StaticResource SmallSpacing}"
 													HorizontalOptions="Center" VerticalOptions="Center"
-													IsVisible="{Binding FirstPhotoSource, Converter={converters:OnlyShowNonEmpty}}">
-							<Border Style="{StaticResource OutlinedImageButtonBorder}" Padding="0" WidthRequest="250" HeightRequest="250" HorizontalOptions="Center">
-								<Image Source="{Binding FirstPhotoSource}" Rotation="{Binding FirstPhotoRotation}"
-										  Aspect="AspectFit" Margin="0">
-									<Image.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding ImageTappedCommand}"/>
-									</Image.GestureRecognizers>
-								</Image>
-							</Border>
+													IsVisible="{Binding HasPhotos}">
+							
+							<CarouselView x:Name="CarouselView"
+								 IsSwipeEnabled="{Binding Path=IsSwipeEnabled}"
+								 HorizontalOptions="FillAndExpand"
+								 VerticalOptions="FillAndExpand"
+								 ItemsSource="{Binding Photos}"
+								 IndicatorView="{x:Reference IndicatorView}">
+								<CarouselView.ItemTemplate>
+									<DataTemplate x:DataType="photos:Photo">
+										<Border Style="{StaticResource OutlinedImageButtonBorder}" Padding="0" WidthRequest="250" HeightRequest="250" HorizontalOptions="Center">
+											<Image Source="{Binding Source}" Rotation="{Binding Path=Rotation}" Aspect="AspectFill"/>
+										</Border>
+									</DataTemplate>
+								</CarouselView.ItemTemplate>
+							</CarouselView>
+
+							<IndicatorView x:Name="IndicatorView"
+								HorizontalOptions="Center"
+								Padding="0,0,0,0"
+								HeightRequest="20"
+								IsVisible="{Binding IsSwipeEnabled}">
+								<IndicatorView.Margin>
+									<OnPlatform x:TypeArguments="Thickness">
+										<On Platform="iOS" Value="0,-1,0,0"/>
+									</OnPlatform>
+								</IndicatorView.Margin>
+							</IndicatorView>
+
 							<VerticalStackLayout HorizontalOptions="Center" VerticalOptions="Center" Spacing="0">
 								<Label Style="{StaticResource BoldItemTitleLabel}" Text="{Binding FullName}" HorizontalOptions="Center" Margin="0" Padding="0" />
 								<Label Style="{StaticResource InfoLabel}" Text="{Binding PersonalNumber}" HorizontalOptions="Center" Margin="0" Padding="0" />

--- a/NeuroAccessMaui/UI/Pages/Identity/ViewIdentity/ViewIdentityViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Identity/ViewIdentity/ViewIdentityViewModel.cs
@@ -1,7 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using NeuroAccessMaui.Extensions;
-using NeuroAccessMaui.UI.Popups.Image;
 using NeuroAccessMaui.Resources.Languages;
 using NeuroAccessMaui.Services;
 using NeuroAccessMaui.Services.Contacts;

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.406",
+    "version": "8.0.407",
     "allowPrerelease": false,
     "rollForward": "disable"
   }


### PR DESCRIPTION
Changes the image in ViewIdentityPage.xaml to a CarouselView with images.

If there are more images (i.e attachments on the account) than 1 the CarouselView will be scrollable and display an indicator showing the current and amount of images.

This means that tapping the image no longer opens a popup