### PR TITLE
Bugfix/http

### DIFF
--- a/NeuroAccessMaui/App.xaml.cs
+++ b/NeuroAccessMaui/App.xaml.cs
@@ -1,6 +1,9 @@
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Net.Http.Headers;
+using System.Net.Security;
 using System.Reflection;
+using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using EDaler;
 using Microsoft.Maui.Controls.Internals;
@@ -90,16 +93,16 @@ namespace NeuroAccessMaui
 		private static readonly TaskCompletionSource<bool> servicesSetup = new();
 		private static readonly TaskCompletionSource<bool> defaultInstantiatedSource = new();
 
-        /// <summary>
-        /// Flag indicating if this instance is “resuming” an already-started app.
-        /// 
-        /// The App class is not actually a singleton. Each time Android MainActivity is destroyed and then created again, a new instance
-        /// of the App class will be created, its OnStart method will be called and its OnResume method will not be called. This happens,
-        /// for example, on Android when the user presses the back button and then navigates to the app again. However, the App class
-        /// doesn't seem to work properly (should it?) when this happens (some chaos happens here and there), so we pretend that
-        /// there is only one instance (see the references to onStartResumesApplication).
-        /// </summary>
-        private bool onStartResumesApplication;
+		/// <summary>
+		/// Flag indicating if this instance is “resuming” an already-started app.
+		/// 
+		/// The App class is not actually a singleton. Each time Android MainActivity is destroyed and then created again, a new instance
+		/// of the App class will be created, its OnStart method will be called and its OnResume method will not be called. This happens,
+		/// for example, on Android when the user presses the back button and then navigates to the app again. However, the App class
+		/// doesn't seem to work properly (should it?) when this happens (some chaos happens here and there), so we pretend that
+		/// there is only one instance (see the references to onStartResumesApplication).
+		/// </summary>
+		private bool onStartResumesApplication;
 
 		#endregion
 
@@ -270,7 +273,7 @@ namespace NeuroAccessMaui
 
 		private void HandleStartupException(Exception Ex)
 		{
-            Ex = Log.UnnestException(Ex);
+			Ex = Log.UnnestException(Ex);
 			ServiceRef.LogService.SaveExceptionDump("StartPage", Ex.ToString());
 			this.DisplayBootstrapErrorPage(Ex.Message, Ex.StackTrace ?? string.Empty);
 			return;
@@ -366,38 +369,38 @@ namespace NeuroAccessMaui
 			servicesSetup.TrySetResult(true);
 		}
 
-        #endregion
+		#endregion
 
-        #region Startup / Resume
+		#region Startup / Resume
 
-        public async Task OnBackgroundStart()
-        {
-            if (this.onStartResumesApplication)
-            {
-                this.onStartResumesApplication = false;
-                await this.ResumeAsync(isBackground: true);
-                return;
-            }
+		public async Task OnBackgroundStart()
+		{
+			if (this.onStartResumesApplication)
+			{
+				this.onStartResumesApplication = false;
+				await this.ResumeAsync(isBackground: true);
+				return;
+			}
 
-            // Asynchronously wait up to 60 seconds.
-            if (!await this.initCompleted.WaitAsync(TimeSpan.FromSeconds(60)))
-                throw new Exception("Initialization did not complete in time.");
-        }
+			// Asynchronously wait up to 60 seconds.
+			if (!await this.initCompleted.WaitAsync(TimeSpan.FromSeconds(60)))
+				throw new Exception("Initialization did not complete in time.");
+		}
 
-        protected override async void OnStart()
-        {
-            if (this.onStartResumesApplication)
-            {
-                this.onStartResumesApplication = false;
-                this.OnResume();
-                return;
-            }
+		protected override async void OnStart()
+		{
+			if (this.onStartResumesApplication)
+			{
+				this.onStartResumesApplication = false;
+				this.OnResume();
+				return;
+			}
 
-            if (!await this.initCompleted.WaitAsync(TimeSpan.FromSeconds(60)))
-                throw new Exception("Initialization did not complete in time.");
-        }
+			if (!await this.initCompleted.WaitAsync(TimeSpan.FromSeconds(60)))
+				throw new Exception("Initialization did not complete in time.");
+		}
 
-        public async Task ResumeAsync(bool isBackground)
+		public async Task ResumeAsync(bool isBackground)
 		{
 			appInstance = this;
 			this.startupCancellation = new CancellationTokenSource();
@@ -893,7 +896,7 @@ namespace NeuroAccessMaui
 			MainThread.BeginInvokeOnMainThread(async () =>
 			{
 				bool Result = await AuthenticateUserOnMainThreadAsync(purpose, force);
-				if(Result)
+				if (Result)
 					lastAuthenticationTime = DateTime.Now;
 				Tcs.TrySetResult(Result);
 			});
@@ -1066,6 +1069,123 @@ namespace NeuroAccessMaui
 			AppActivated?.Invoke(Current, EventArgs.Empty);
 		}
 
+		/// <summary>
+		/// Callback for validating SSL certificates.
+		/// This method is called when a remote certificate is received during HTTPS communication.
+		/// Fixed an issue with incomplete revocation check in the chain on iOS devices.
+		/// </summary>
+		public static void ValidateCertificateCallback(object? Sender, RemoteCertificateEventArgs Args)
+		{
+			Args.IsValid = true; // Accept certificate
+
+			// Check for incomplete revocation check in the chain
+			if ((Args.SslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) != 0 && Args.Chain is not null)
+			{
+				foreach (X509ChainStatus Status in Args.Chain.ChainStatus)
+				{
+					// Apple-specific error code for incomplete revocation check
+					if (Status.Status == X509ChainStatusFlags.RevocationStatusUnknown ||
+						Status.Status == X509ChainStatusFlags.OfflineRevocation)
+					{
+						continue; // Ignore this error
+					}
+					if (Status.Status != X509ChainStatusFlags.NoError)
+						Args.IsValid = false; // Reject certificate
+				}
+			}
+			else if (Args.SslPolicyErrors != SslPolicyErrors.None)
+				Args.IsValid = false; // Reject certificate
+
+			if (Args.IsValid is not null && Args.IsValid == true)
+				return; // Accept certificate
+
+			try
+			{
+
+				StringBuilder SniffMsg = new StringBuilder();
+
+				SniffMsg.AppendLine("Invalid certificate received (and rejected).");
+
+				SniffMsg.AppendLine();
+				SniffMsg.Append("sslPolicyErrors: ");
+				SniffMsg.AppendLine(Args.SslPolicyErrors.ToString());
+				SniffMsg.Append("Subject: ");
+				SniffMsg.AppendLine(Args.Certificate?.Subject);
+				SniffMsg.Append("Issuer: ");
+				SniffMsg.AppendLine(Args.Certificate?.Issuer);
+				// Log the certificate details
+				byte[]? Cert = Args.Certificate?.Export(X509ContentType.Cert);    // Avoids SafeHandle exception when accessing certificate later.
+
+				if (Cert is not null)
+				{
+					StringBuilder Base64 = new StringBuilder();
+					string s;
+					int c = Cert?.Length ?? 0;
+					int i = 0;
+					int j;
+
+					while (i < c)
+					{
+						j = Math.Min(57, c - i);
+						s = Convert.ToBase64String(Cert!, i, j);
+						i += j;
+
+						Base64.Append(s);
+
+						if (i < c)
+							Base64.AppendLine();
+					}
+
+					SniffMsg.Append("BASE64(Cert): ");
+					SniffMsg.Append(Base64);
+				}
+				SniffMsg.AppendLine();
+
+				SniffMsg.AppendLine("Nr of elements in chain: ");
+				SniffMsg.Append(Args.Chain?.ChainElements.Count ?? 0);
+				SniffMsg.AppendLine();
+				SniffMsg.AppendLine("Chain status: ");
+				foreach (X509ChainStatus Status in Args.Chain?.ChainStatus ?? [])
+				{
+					SniffMsg.Append("Status: ");
+					SniffMsg.AppendLine(Status.Status.ToString());
+					SniffMsg.Append("StatusInformation: ");
+					SniffMsg.AppendLine(Status.StatusInformation);
+					SniffMsg.AppendLine();
+				}
+
+
+				SniffMsg.AppendLine("Chain elements:");
+				if (Args.Chain is not null)
+				{
+					foreach (X509ChainElement Element in Args.Chain.ChainElements)
+					{
+						SniffMsg.Append("Certificate: ");
+						SniffMsg.AppendLine(Element.Certificate.GetNameInfo(X509NameType.SimpleName, false));
+						SniffMsg.Append("Certificate: ");
+						SniffMsg.AppendLine(Element.Certificate.GetNameInfo(X509NameType.DnsName, false));
+						SniffMsg.Append("Certificate: ");
+						SniffMsg.AppendLine(Element.Certificate.GetNameInfo(X509NameType.EmailName, false));
+						SniffMsg.Append("Certificate: ");
+						SniffMsg.AppendLine(Element.Certificate.GetNameInfo(X509NameType.UpnName, false));
+						SniffMsg.Append("Subject: ");
+						SniffMsg.AppendLine(Element.Certificate.Subject);
+						SniffMsg.Append("Issuer: ");
+						SniffMsg.AppendLine(Element.Certificate.Issuer);
+						SniffMsg.AppendLine("Info: ");
+						SniffMsg.Append(Element.Information);
+						SniffMsg.AppendLine();
+					}
+				}
+
+
+				ServiceRef.LogService.LogWarning(SniffMsg.ToString());
+			}
+			catch (Exception Ex)
+			{
+				ServiceRef.LogService.LogException(Ex);
+			}
+		}
 
 		#endregion
 	}

--- a/NeuroAccessMaui/Services/EventLog/ILogService.cs
+++ b/NeuroAccessMaui/Services/EventLog/ILogService.cs
@@ -8,7 +8,7 @@ namespace NeuroAccessMaui.Services.EventLog
 	/// A log implementation for logging warnings, exceptions and events.
 	/// </summary>
 	[DefaultImplementation(typeof(LogService))]
-	public interface ILogService : ILoadableService
+	public interface ILogService : ILoadableService, IDisposable
 	{
 		/// <summary>
 		/// Starts a debug log session. This log all events to a file

--- a/NeuroAccessMaui/Services/EventLog/LogService.cs
+++ b/NeuroAccessMaui/Services/EventLog/LogService.cs
@@ -232,47 +232,62 @@ namespace NeuroAccessMaui.Services.EventLog
 #endif
 			return Task.CompletedTask;
 		}
-    public async Task StartDebugLogSessionAsync()
-    {
-        string FileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), debugLogFileName);
+		public async Task StartDebugLogSessionAsync()
+		{
+			string FileName = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), debugLogFileName);
 
-        // If an old session is still open, end it first
-        if (this.debugSink != null)
+			// If an old session is still open, end it first
+			if (this.debugSink != null)
 				await this.EndDebugLogSessionAsync();
 
-        if (File.Exists(FileName))
-            File.Delete(FileName);
+			if (File.Exists(FileName))
+				File.Delete(FileName);
 
-        // Create and keep references
-        this.debugFileStream = new FileStream(FileName, FileMode.Create, FileAccess.Write, FileShare.Read);
-        this.debugTextWriter = new StreamWriter(this.debugFileStream, Encoding.UTF8)
-        {
-            AutoFlush = true
-        };
-        this.debugSink = new TextWriterEventSink(debugLogFileName, this.debugTextWriter);
+			// Create and keep references
+			this.debugFileStream = new FileStream(FileName, FileMode.Create, FileAccess.Write, FileShare.Read);
+			this.debugTextWriter = new StreamWriter(this.debugFileStream, Encoding.UTF8)
+			{
+				AutoFlush = true
+			};
+			this.debugSink = new TextWriterEventSink(debugLogFileName, this.debugTextWriter);
 
-        this.AddListener(this.debugSink);
-    }
+			this.AddListener(this.debugSink);
+		}
 
-    public async Task EndDebugLogSessionAsync()
-    {
-        if (this.debugSink is null)
-            return;
+		public async Task EndDebugLogSessionAsync()
+		{
+			if (this.debugSink is null)
+				return;
 
 			// Unregister the sink so no more events are written
 			this.RemoveListener(this.debugSink);
 
-        // Dispose the sink (it doesn't own the writer, so no-op, but good practice)
-        await this.debugSink.DisposeAsync();
-        this.debugSink = null;
+			// Dispose the sink (it doesn't own the writer, so no-op, but good practice)
+			await this.debugSink.DisposeAsync();
+			this.debugSink = null;
 
-        // Dispose the writer and the file stream
-        this.debugTextWriter?.Dispose();
-        this.debugTextWriter = null;
+			// Dispose the writer and the file stream
+			this.debugTextWriter?.Dispose();
+			this.debugTextWriter = null;
 
-        this.debugFileStream?.Dispose();
-        this.debugFileStream = null;
-    }
+			this.debugFileStream?.Dispose();
+			this.debugFileStream = null;
+		}
 
+        /// <summary>
+        /// Disposes any active debug log session and suppresses finalization.
+        /// </summary>
+        public void Dispose()
+        {
+            // If a debug session is still open, clean it up synchronously
+            if (this.debugSink is not null || this.debugTextWriter is not null || this.debugFileStream is not null)
+            {
+                // Block on the async cleanup
+                this.EndDebugLogSessionAsync().GetAwaiter().GetResult();
+            }
+
+            // Suppress finalization if a finalizer is ever added
+            GC.SuppressFinalize(this);
+        }
 	}
 }

--- a/NeuroAccessMaui/UI/Pages/Registration/Views/ChooseProviderViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Registration/Views/ChooseProviderViewModel.cs
@@ -163,6 +163,8 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 					AcceptLanguage += ";q=1,en;q=0.9";
 
 				ContentResponse Result = await InternetContent.GetAsync(DomainInfo,
+					null,                               // Certificate
+					App.ValidateCertificateCallback,          // RemoteCertificateValidator
 					new KeyValuePair<string, string>("Accept", "application/json"),
 					new KeyValuePair<string, string>("Accept-Language", AcceptLanguage),
 					new KeyValuePair<string, string>("Accept-Encoding", "0"));

--- a/NeuroAccessMaui/UI/Pages/Registration/Views/ContactSupportViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Registration/Views/ContactSupportViewModel.cs
@@ -75,7 +75,10 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 			try
 			{
 				ContentResponse Result = await InternetContent.PostAsync(
-					new Uri("https://" + Constants.Domains.IdDomain + "/ID/CountryCode.ws"), string.Empty,
+					new Uri("https://" + Constants.Domains.IdDomain + "/ID/CountryCode.ws"), 
+					string.Empty,
+					null,                               // Certificate
+					App.ValidateCertificateCallback,          // RemoteCertificateValidator
 					new KeyValuePair<string, string>("Accept", "application/json"));
 
 				if (Result.HasError)
@@ -213,7 +216,10 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 						 { "Nr", FullPhoneNumber },
 						 { "AppName", Constants.Application.Name },
 						 { "Language", CultureInfo.CurrentCulture.TwoLetterISOLanguageName }
-					 }, new KeyValuePair<string, string>("Accept", "application/json"));
+					 },
+					null,                               // Certificate
+					App.ValidateCertificateCallback,          // RemoteCertificateValidator
+					 new KeyValuePair<string, string>("Accept", "application/json"));
 
 				PhoneSendResult.AssertOk();
 
@@ -272,7 +278,10 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 
 				ContentResponse Response = await InternetContent.PostAsync(
 					new Uri("https://" + Constants.Domains.IdDomain + "/ID/VerifyNumber.ws"),
-					parameters, new KeyValuePair<string, string>("Accept", "application/json"));
+					parameters,
+					null,                               // Certificate
+					App.ValidateCertificateCallback,          // RemoteCertificateValidator
+					new KeyValuePair<string, string>("Accept", "application/json"));
 
 				Response.AssertOk();
 
@@ -369,6 +378,8 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 				try
 				{
 					ContentBinaryResponse Response = await InternetContent.PostAsync(Uri, Encoding.ASCII.GetBytes(Code), "text/plain",
+						null,                               // Certificate
+						App.ValidateCertificateCallback,          // RemoteCertificateValidator
 						new KeyValuePair<string, string>("Accept", "text/plain"));
 					Response.AssertOk();
 

--- a/NeuroAccessMaui/UI/Pages/Registration/Views/FinalizeViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Registration/Views/FinalizeViewModel.cs
@@ -58,6 +58,8 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 					AcceptLanguage += ";q=1,en;q=0.9";
 
 				ContentResponse Result = await InternetContent.GetAsync(DomainInfo,
+					null,                               // Certificate
+					App.ValidateCertificateCallback,          // RemoteCertificateValidator
 					new KeyValuePair<string, string>("Accept", "application/json"),
 					new KeyValuePair<string, string>("Accept-Language", AcceptLanguage),
 					new KeyValuePair<string, string>("Accept-Encoding", "0"));

--- a/NeuroAccessMaui/UI/Pages/Registration/Views/ValidateEmailViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Registration/Views/ValidateEmailViewModel.cs
@@ -144,7 +144,10 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 						{ "EMail", this.EmailText },
 						{ "AppName", Constants.Application.Name },
 						{ "Language", CultureInfo.CurrentCulture.TwoLetterISOLanguageName }
-					}, new KeyValuePair<string, string>("Accept", "application/json"));
+					},
+					null,                               // Certificate
+					App.ValidateCertificateCallback,          // RemoteCertificateValidator
+					new KeyValuePair<string, string>("Accept", "application/json"));
 
 				SendResult.AssertOk();
 
@@ -167,7 +170,10 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 							{
 								{ "EMail", this.EmailText },
 								{ "Code", int.Parse(Code, NumberStyles.None, CultureInfo.InvariantCulture) }
-							}, new KeyValuePair<string, string>("Accept", "application/json"));
+							},
+							null,                               // Certificate
+							App.ValidateCertificateCallback,          // RemoteCertificateValidator
+							new KeyValuePair<string, string>("Accept", "application/json"));
 
 						VerifyResult.AssertOk();
 
@@ -233,7 +239,10 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 						{ "EMail", this.EmailText },
 						{ "AppName", Constants.Application.Name },
 						{ "Language", CultureInfo.CurrentCulture.TwoLetterISOLanguageName }
-					}, new KeyValuePair<string, string>("Accept", "application/json"));
+					},
+					null,                               // Certificate
+					App.ValidateCertificateCallback,          // RemoteCertificateValidator
+					new KeyValuePair<string, string>("Accept", "application/json"));
 
 				SendResult.AssertOk();
 

--- a/NeuroAccessMaui/UI/Pages/Registration/Views/ValidatePhoneViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Registration/Views/ValidatePhoneViewModel.cs
@@ -1,5 +1,8 @@
 ﻿using System.ComponentModel;
 using System.Globalization;
+using System.Net.Security;
+using System.Security.Cryptography.X509Certificates;
+using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mopups.Services;
@@ -21,6 +24,134 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 			: base(RegistrationStep.ValidatePhone)
 		{
 		}
+		bool MyCertValidationCallback(
+	object sender,
+	RemoteCertificateEventArgs args)
+		{
+			string script =
+				"""
+			s1:="MIIGAzCCBOugAwIBAgISBT7/fFaZaWnMuGUAuUMuwsk9MA0GCSqGSIb3DQEBCwUAMDMxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQwwCgYDVQQDEwNSMTAwHhcNMjUwNTEyMjE1MDE5WhcNMjUwODEwMjE1MDE4WjAYMRYwFAYDVQQDEw1pZC50YWdyb290LmlvMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr+METmLwZDyBFaoZ56k8KrwzY+hVFGagIoGZGB/iuXw8p5ywF8y2P+BwDNjdH2KYf2ek2N1IWM+Zx2SWvC/qyO9jlKDzn9k0KNQIqNdz0utWQOJWgoMwsrp9wqTxkxRSekhwn1scNnW38SDyPOi70GPhmkdQhtnVy0JFvKTToSpkrDSzs+z57yTPbs3RWtNeTpTj/vqrx0zUeOfjvw6cd2S8eqvK3QMP/yrU2llsc6wr0CRy1d4a35vlS2zvUOGIqORgVz50q7jaVETZEc4Hr2vZF16ZY1rx+Z18DyfLrSEIKSeaPwe85aHKxZsC5xm9IaSqa/DVWpSSQD5or1VyFjWNaokIbjz5gdJFRsVonq+AqhGTu3y6tEWe+V00hUMKeeOO7skkXxqUF2vZRnqMTJ2b7ZBvxJVCvXanTRevI94YJnTDiZFzEXU1ykVzVeMcd3sZG3Tc7zmx+DIl/Zl76DW+y1nIINPQNCfFYLTOyfS6AfZdMxepo5kojtCwWr5GSnJMx5TUSpA4eA4UqMsMypsCDiHfrK1zLBYl7xKqPQbsYXcuaIGypmx/s9PVyFqMQ86paA6BhG1GidEBqAWaigXEuDKqvOhSXe0JBRw5awnAJpe64RM/Orq7QY+FpE3Y8kCRQn/3Y5hB/SdCZFzc9m7NoIJ16zsG8GZUK6sqtTkCAwEAAaOCAiowggImMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUMloeWe/000MqWUr0ke3daUH8lnUwHwYDVR0jBBgwFoAUu7zDR6XkvKnGw6RyDBCNojXhyOgwMwYIKwYBBQUHAQEEJzAlMCMGCCsGAQUFBzAChhdodHRwOi8vcjEwLmkubGVuY3Iub3JnLzAlBgNVHREEHjAcgg1pZC50YWdyb290LmlvggtxdWlja2xvZy5pbjATBgNVHSAEDDAKMAgGBmeBDAECATAuBgNVHR8EJzAlMCOgIaAfhh1odHRwOi8vcjEwLmMubGVuY3Iub3JnLzYyLmNybDCCAQQGCisGAQQB1nkCBAIEgfUEgfIA8AB2AO08S9boBsKkogBX28sk4jgB31Ev7cSGxXAPIN23Pj/gAAABlsavwP0AAAQDAEcwRQIgPzElmtQTPbl5L5F+jsHiRavJaBOzaHYwDk4jKfM95N4CIQDsE44zr+ZaoXwcosnQUNiwuYSp8MiYxsNP4ADfLn3/2wB2ABLxTjS9U3JMhAYZw48/ehP457Vih4icbTAFhOvlhiY6AAABlsavwQEAAAQDAEcwRQIgfI+LX2Q4qkCod1ljBkoMSDxUJqM+V6JC7Ls1OjUZX1oCIQCZa9T3jRgGtQW1MW6Zo2jLBBR6nV3WSB04RBHVo+vRwTANBgkqhkiG9w0BAQsFAAOCAQEAqru4IAPZKaDE5BGsienLvaU6fAODQRXDu5MezZKMrgkXwyeiGkXGSD8Yq+LC60ybD3RvJuoF0qeUiagizjDLdmVFBhZBlBINbMzG3os7eBZ4KbCH8SWW0uT51wkRJSKEvPw13owvqUpB4P6HGTBYE+IE+0aHOQ0x/Y8b3ovvYm3BaN1ZLe0IZsExI3SFBQo4oC27+YdpqWTAuAgZilnljeTIsMOG7Jw48gUamS4FgcsWztZG7zh3eoXFws+r15jmrX+xWPLz0A+L4ObMwuKYVwNDFtfPJAVA7ld4mnMzMq33UbU8aEMXKxlZi6JMHcoX2Ei0WOwXgzOH9PMxv8Rgng==";
+			s2:="MIIGAzCCBOugAwIBAgISBT7/fFaZaWnMuGUAuUMuwsk9MA0GCSqGSIb3DQEBCwUAMDMxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQwwCgYDVQQDEwNSMTAwHhcNMjUwNTEyMjE1MDE5WhcNMjUwODEwMjE1MDE4WjAYMRYwFAYDVQQDEw1pZC50YWdyb290LmlvMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr+METmLwZDyBFaoZ56k8KrwzY+hVFGagIoGZGB/iuXw8p5ywF8y2P+BwDNjdH2KYf2ek2N1IWM+Zx2SWvC/qyO9jlKDzn9k0KNQIqNdz0utWQOJWgoMwsrp9wqTxkxRSekhwn1scNnW38SDyPOi70GPhmkdQhtnVy0JFvKTToSpkrDSzs+z57yTPbs3RWtNeTpTj/vqrx0zUeOfjvw6cd2S8eqvK3QMP/yrU2llsc6wr0CRy1d4a35vlS2zvUOGIqORgVz50q7jaVETZEc4Hr2vZF16ZY1rx+Z18DyfLrSEIKSeaPwe85aHKxZsC5xm9IaSqa/DVWpSSQD5or1VyFjWNaokIbjz5gdJFRsVonq+AqhGTu3y6tEWe+V00hUMKeeOO7skkXxqUF2vZRnqMTJ2b7ZBvxJVCvXanTRevI94YJnTDiZFzEXU1ykVzVeMcd3sZG3Tc7zmx+DIl/Zl76DW+y1nIINPQNCfFYLTOyfS6AfZdMxepo5kojtCwWr5GSnJMx5TUSpA4eA4UqMsMypsCDiHfrK1zLBYl7xKqPQbsYXcuaIGypmx/s9PVyFqMQ86paA6BhG1GidEBqAWaigXEuDKqvOhSXe0JBRw5awnAJpe64RM/Orq7QY+FpE3Y8kCRQn/3Y5hB/SdCZFzc9m7NoIJ16zsG8GZUK6sqtTkCAwEAAaOCAiowggImMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUMloeWe/000MqWUr0ke3daUH8lnUwHwYDVR0jBBgwFoAUu7zDR6XkvKnGw6RyDBCNojXhyOgwMwYIKwYBBQUHAQEEJzAlMCMGCCsGAQUFBzAChhdodHRwOi8vcjEwLmkubGVuY3Iub3JnLzAlBgNVHREEHjAcgg1pZC50YWdyb290LmlvggtxdWlja2xvZy5pbjATBgNVHSAEDDAKMAgGBmeBDAECATAuBgNVHR8EJzAlMCOgIaAfhh1odHRwOi8vcjEwLmMubGVuY3Iub3JnLzYyLmNybDCCAQQGCisGAQQB1nkCBAIEgfUEgfIA8AB2AO08S9boBsKkogBX28sk4jgB31Ev7cSGxXAPIN23Pj/gAAABlsavwP0AAAQDAEcwRQIgPzElmtQTPbl5L5F+jsHiRavJaBOzaHYwDk4jKfM95N4CIQDsE44zr+ZaoXwcosnQUNiwuYSp8MiYxsNP4ADfLn3/2wB2ABLxTjS9U3JMhAYZw48/ehP457Vih4icbTAFhOvlhiY6AAABlsavwQEAAAQDAEcwRQIgfI+LX2Q4qkCod1ljBkoMSDxUJqM+V6JC7Ls1OjUZX1oCIQCZa9T3jRgGtQW1MW6Zo2jLBBR6nV3WSB04RBHVo+vRwTANBgkqhkiG9w0BAQsFAAOCAQEAqru4IAPZKaDE5BGsienLvaU6fAODQRXDu5MezZKMrgkXwyeiGkXGSD8Yq+LC60ybD3RvJuoF0qeUiagizjDLdmVFBhZBlBINbMzG3os7eBZ4KbCH8SWW0uT51wkRJSKEvPw13owvqUpB4P6HGTBYE+IE+0aHOQ0x/Y8b3ovvYm3BaN1ZLe0IZsExI3SFBQo4oC27+YdpqWTAuAgZilnljeTIsMOG7Jw48gUamS4FgcsWztZG7zh3eoXFws+r15jmrX+xWPLz0A+L4ObMwuKYVwNDFtfPJAVA7ld4mnMzMq33UbU8aEMXKxlZi6JMHcoX2Ei0WOwXgzOH9PMxv8Rgng==";
+
+			printline(s1=s2);
+
+			C:=Create(System.Security.Cryptography.X509Certificates.X509Certificate2,base64decode(s1));
+			R:=C.Verify();
+			printline(R);
+
+			""";
+
+			//object? res = Waher.Script.Expression.Eval(script);
+
+			if (args.SslPolicyErrors == SslPolicyErrors.None)
+			{
+				args.IsValid = true; // Accept certificate
+				return true; 
+			}
+			// Check for incomplete revocation check in the chain
+			if ((args.SslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) != 0 && args.Chain is not null)
+			{
+				foreach (var status in args.Chain.ChainStatus)
+				{
+					// Apple-specific error code for incomplete revocation check
+					if (status.Status == X509ChainStatusFlags.RevocationStatusUnknown ||
+						status.Status == X509ChainStatusFlags.OfflineRevocation)
+					{
+						// Optionally log or handle as needed
+						continue; // Ignore this error
+					}
+					if (status.Status != X509ChainStatusFlags.NoError)
+						return false; // Fail on other errors
+				}
+				args.IsValid = true; // Accept certificate
+				return true; // Only revocation check failed, allow
+				
+			}
+
+			return false;
+
+
+		//	ServiceRef.LogService.LogDebug("Result: " + res?.ToString() ?? "null");
+
+			byte[] Cert = args.Certificate?.Export(X509ContentType.Cert);    // Avoids SafeHandle exception when accessing certificate later.
+
+
+			StringBuilder Base64 = new StringBuilder();
+			string s;
+			int c = Cert?.Length ?? 0;
+			int i = 0;
+			int j;
+
+			while (i < c)
+			{
+				j = Math.Min(57, c - i);
+				s = Convert.ToBase64String(Cert, i, j);
+				i += j;
+
+				Base64.Append(s);
+
+				if (i < c)
+					Base64.AppendLine();
+			}
+
+			StringBuilder SniffMsg = new StringBuilder();
+
+			SniffMsg.AppendLine("Invalid certificate received (and rejected).");
+
+			SniffMsg.AppendLine();
+			SniffMsg.Append("sslPolicyErrors: ");
+			SniffMsg.AppendLine(args.SslPolicyErrors.ToString());
+			SniffMsg.Append("Subject: ");
+			SniffMsg.AppendLine(args.Certificate?.Subject);
+			SniffMsg.Append("Issuer: ");
+			SniffMsg.AppendLine(args.Certificate?.Issuer);
+			SniffMsg.Append("BASE64(Cert): ");
+			SniffMsg.Append(Base64);
+			SniffMsg.AppendLine();
+
+			SniffMsg.AppendLine("Nr of elements in chain: ");
+			SniffMsg.Append(args.Chain.ChainElements.Count);
+			SniffMsg.AppendLine();
+			SniffMsg.AppendLine("Chain status: ");
+			foreach (X509ChainStatus Status in args.Chain.ChainStatus)
+			{
+				SniffMsg.Append("Status: ");
+				SniffMsg.AppendLine(Status.Status.ToString());
+				SniffMsg.Append("StatusInformation: ");
+				SniffMsg.AppendLine(Status.StatusInformation);
+				SniffMsg.AppendLine();
+
+			}
+
+			SniffMsg.AppendLine("Chain elements:");
+			foreach (X509ChainElement Element in args.Chain.ChainElements)
+			{
+				SniffMsg.Append("Subject: ");
+				SniffMsg.AppendLine(Element.Certificate.Subject);
+				SniffMsg.Append("Issuer: ");
+				SniffMsg.AppendLine(Element.Certificate.Issuer);
+				SniffMsg.AppendLine("Info: ");
+				SniffMsg.Append(Element.Information);
+				SniffMsg.AppendLine();
+			}
+
+			try
+			{
+				ServiceRef.LogService.LogWarning(SniffMsg.ToString());
+			}
+			catch (Exception ex2)
+			{
+				ServiceRef.LogService.LogException(ex2);
+			}
+			//	X509Certificate? Cert2 = args.Chain.ChainElements.FirstOrDefault()?.Certificate;
+			//	if(Cert2 is not null)
+			//		MyCertValidationCallback(null, new RemoteCertificateEventArgs(Cert2, null, args.SslPolicyErrors));
+
+			return false;
+		}
+		// Inspect args.ServerCertificate, args.Chain, args.PolicyErrors etc.
+		// Return true to accept the cert, false to reject.
+		//return MyOwnLogic(args.ServerCertificate, args.Chain, args.PolicyErrors);
 
 		/// <inheritdoc/>
 		protected override async Task OnInitialize()
@@ -41,9 +172,12 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 				try
 				{
 					ContentResponse Result = await InternetContent.PostAsync(
-						new Uri("https://" + Constants.Domains.IdDomain + "/ID/CountryCode.ws"), string.Empty,
-						new KeyValuePair<string, string>("Accept", "application/json"));
-
+						new Uri("https://" + Constants.Domains.IdDomain + "/ID/CountryCode.ws"),
+						string.Empty,                       // Data
+		//				null,                               // Certificate
+		//				(object? sender, RemoteCertificateEventArgs e) => MyCertValidationCallback(sender, e),          // RemoteCertificateValidator
+						new KeyValuePair<string, string>("Accept", "application/json")  // Headers
+					);
 					Result.AssertOk();
 
 					if ((Result.Decoded is Dictionary<string, object> Response) &&
@@ -60,6 +194,7 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 				}
 			}
 		}
+
 
 		/// <inheritdoc/>
 		protected override async Task OnDispose()

--- a/NeuroAccessMaui/UI/Pages/Registration/Views/ValidatePhoneViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Registration/Views/ValidatePhoneViewModel.cs
@@ -1,8 +1,5 @@
 ﻿using System.ComponentModel;
 using System.Globalization;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
-using System.Text;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Mopups.Services;
@@ -24,134 +21,6 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 			: base(RegistrationStep.ValidatePhone)
 		{
 		}
-		bool MyCertValidationCallback(
-	object sender,
-	RemoteCertificateEventArgs args)
-		{
-			string script =
-				"""
-			s1:="MIIGAzCCBOugAwIBAgISBT7/fFaZaWnMuGUAuUMuwsk9MA0GCSqGSIb3DQEBCwUAMDMxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQwwCgYDVQQDEwNSMTAwHhcNMjUwNTEyMjE1MDE5WhcNMjUwODEwMjE1MDE4WjAYMRYwFAYDVQQDEw1pZC50YWdyb290LmlvMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr+METmLwZDyBFaoZ56k8KrwzY+hVFGagIoGZGB/iuXw8p5ywF8y2P+BwDNjdH2KYf2ek2N1IWM+Zx2SWvC/qyO9jlKDzn9k0KNQIqNdz0utWQOJWgoMwsrp9wqTxkxRSekhwn1scNnW38SDyPOi70GPhmkdQhtnVy0JFvKTToSpkrDSzs+z57yTPbs3RWtNeTpTj/vqrx0zUeOfjvw6cd2S8eqvK3QMP/yrU2llsc6wr0CRy1d4a35vlS2zvUOGIqORgVz50q7jaVETZEc4Hr2vZF16ZY1rx+Z18DyfLrSEIKSeaPwe85aHKxZsC5xm9IaSqa/DVWpSSQD5or1VyFjWNaokIbjz5gdJFRsVonq+AqhGTu3y6tEWe+V00hUMKeeOO7skkXxqUF2vZRnqMTJ2b7ZBvxJVCvXanTRevI94YJnTDiZFzEXU1ykVzVeMcd3sZG3Tc7zmx+DIl/Zl76DW+y1nIINPQNCfFYLTOyfS6AfZdMxepo5kojtCwWr5GSnJMx5TUSpA4eA4UqMsMypsCDiHfrK1zLBYl7xKqPQbsYXcuaIGypmx/s9PVyFqMQ86paA6BhG1GidEBqAWaigXEuDKqvOhSXe0JBRw5awnAJpe64RM/Orq7QY+FpE3Y8kCRQn/3Y5hB/SdCZFzc9m7NoIJ16zsG8GZUK6sqtTkCAwEAAaOCAiowggImMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUMloeWe/000MqWUr0ke3daUH8lnUwHwYDVR0jBBgwFoAUu7zDR6XkvKnGw6RyDBCNojXhyOgwMwYIKwYBBQUHAQEEJzAlMCMGCCsGAQUFBzAChhdodHRwOi8vcjEwLmkubGVuY3Iub3JnLzAlBgNVHREEHjAcgg1pZC50YWdyb290LmlvggtxdWlja2xvZy5pbjATBgNVHSAEDDAKMAgGBmeBDAECATAuBgNVHR8EJzAlMCOgIaAfhh1odHRwOi8vcjEwLmMubGVuY3Iub3JnLzYyLmNybDCCAQQGCisGAQQB1nkCBAIEgfUEgfIA8AB2AO08S9boBsKkogBX28sk4jgB31Ev7cSGxXAPIN23Pj/gAAABlsavwP0AAAQDAEcwRQIgPzElmtQTPbl5L5F+jsHiRavJaBOzaHYwDk4jKfM95N4CIQDsE44zr+ZaoXwcosnQUNiwuYSp8MiYxsNP4ADfLn3/2wB2ABLxTjS9U3JMhAYZw48/ehP457Vih4icbTAFhOvlhiY6AAABlsavwQEAAAQDAEcwRQIgfI+LX2Q4qkCod1ljBkoMSDxUJqM+V6JC7Ls1OjUZX1oCIQCZa9T3jRgGtQW1MW6Zo2jLBBR6nV3WSB04RBHVo+vRwTANBgkqhkiG9w0BAQsFAAOCAQEAqru4IAPZKaDE5BGsienLvaU6fAODQRXDu5MezZKMrgkXwyeiGkXGSD8Yq+LC60ybD3RvJuoF0qeUiagizjDLdmVFBhZBlBINbMzG3os7eBZ4KbCH8SWW0uT51wkRJSKEvPw13owvqUpB4P6HGTBYE+IE+0aHOQ0x/Y8b3ovvYm3BaN1ZLe0IZsExI3SFBQo4oC27+YdpqWTAuAgZilnljeTIsMOG7Jw48gUamS4FgcsWztZG7zh3eoXFws+r15jmrX+xWPLz0A+L4ObMwuKYVwNDFtfPJAVA7ld4mnMzMq33UbU8aEMXKxlZi6JMHcoX2Ei0WOwXgzOH9PMxv8Rgng==";
-			s2:="MIIGAzCCBOugAwIBAgISBT7/fFaZaWnMuGUAuUMuwsk9MA0GCSqGSIb3DQEBCwUAMDMxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MQwwCgYDVQQDEwNSMTAwHhcNMjUwNTEyMjE1MDE5WhcNMjUwODEwMjE1MDE4WjAYMRYwFAYDVQQDEw1pZC50YWdyb290LmlvMIICIjANBgkqhkiG9w0BAQEFAAOCAg8AMIICCgKCAgEAr+METmLwZDyBFaoZ56k8KrwzY+hVFGagIoGZGB/iuXw8p5ywF8y2P+BwDNjdH2KYf2ek2N1IWM+Zx2SWvC/qyO9jlKDzn9k0KNQIqNdz0utWQOJWgoMwsrp9wqTxkxRSekhwn1scNnW38SDyPOi70GPhmkdQhtnVy0JFvKTToSpkrDSzs+z57yTPbs3RWtNeTpTj/vqrx0zUeOfjvw6cd2S8eqvK3QMP/yrU2llsc6wr0CRy1d4a35vlS2zvUOGIqORgVz50q7jaVETZEc4Hr2vZF16ZY1rx+Z18DyfLrSEIKSeaPwe85aHKxZsC5xm9IaSqa/DVWpSSQD5or1VyFjWNaokIbjz5gdJFRsVonq+AqhGTu3y6tEWe+V00hUMKeeOO7skkXxqUF2vZRnqMTJ2b7ZBvxJVCvXanTRevI94YJnTDiZFzEXU1ykVzVeMcd3sZG3Tc7zmx+DIl/Zl76DW+y1nIINPQNCfFYLTOyfS6AfZdMxepo5kojtCwWr5GSnJMx5TUSpA4eA4UqMsMypsCDiHfrK1zLBYl7xKqPQbsYXcuaIGypmx/s9PVyFqMQ86paA6BhG1GidEBqAWaigXEuDKqvOhSXe0JBRw5awnAJpe64RM/Orq7QY+FpE3Y8kCRQn/3Y5hB/SdCZFzc9m7NoIJ16zsG8GZUK6sqtTkCAwEAAaOCAiowggImMA4GA1UdDwEB/wQEAwIFoDAdBgNVHSUEFjAUBggrBgEFBQcDAQYIKwYBBQUHAwIwDAYDVR0TAQH/BAIwADAdBgNVHQ4EFgQUMloeWe/000MqWUr0ke3daUH8lnUwHwYDVR0jBBgwFoAUu7zDR6XkvKnGw6RyDBCNojXhyOgwMwYIKwYBBQUHAQEEJzAlMCMGCCsGAQUFBzAChhdodHRwOi8vcjEwLmkubGVuY3Iub3JnLzAlBgNVHREEHjAcgg1pZC50YWdyb290LmlvggtxdWlja2xvZy5pbjATBgNVHSAEDDAKMAgGBmeBDAECATAuBgNVHR8EJzAlMCOgIaAfhh1odHRwOi8vcjEwLmMubGVuY3Iub3JnLzYyLmNybDCCAQQGCisGAQQB1nkCBAIEgfUEgfIA8AB2AO08S9boBsKkogBX28sk4jgB31Ev7cSGxXAPIN23Pj/gAAABlsavwP0AAAQDAEcwRQIgPzElmtQTPbl5L5F+jsHiRavJaBOzaHYwDk4jKfM95N4CIQDsE44zr+ZaoXwcosnQUNiwuYSp8MiYxsNP4ADfLn3/2wB2ABLxTjS9U3JMhAYZw48/ehP457Vih4icbTAFhOvlhiY6AAABlsavwQEAAAQDAEcwRQIgfI+LX2Q4qkCod1ljBkoMSDxUJqM+V6JC7Ls1OjUZX1oCIQCZa9T3jRgGtQW1MW6Zo2jLBBR6nV3WSB04RBHVo+vRwTANBgkqhkiG9w0BAQsFAAOCAQEAqru4IAPZKaDE5BGsienLvaU6fAODQRXDu5MezZKMrgkXwyeiGkXGSD8Yq+LC60ybD3RvJuoF0qeUiagizjDLdmVFBhZBlBINbMzG3os7eBZ4KbCH8SWW0uT51wkRJSKEvPw13owvqUpB4P6HGTBYE+IE+0aHOQ0x/Y8b3ovvYm3BaN1ZLe0IZsExI3SFBQo4oC27+YdpqWTAuAgZilnljeTIsMOG7Jw48gUamS4FgcsWztZG7zh3eoXFws+r15jmrX+xWPLz0A+L4ObMwuKYVwNDFtfPJAVA7ld4mnMzMq33UbU8aEMXKxlZi6JMHcoX2Ei0WOwXgzOH9PMxv8Rgng==";
-
-			printline(s1=s2);
-
-			C:=Create(System.Security.Cryptography.X509Certificates.X509Certificate2,base64decode(s1));
-			R:=C.Verify();
-			printline(R);
-
-			""";
-
-			//object? res = Waher.Script.Expression.Eval(script);
-
-			if (args.SslPolicyErrors == SslPolicyErrors.None)
-			{
-				args.IsValid = true; // Accept certificate
-				return true; 
-			}
-			// Check for incomplete revocation check in the chain
-			if ((args.SslPolicyErrors & SslPolicyErrors.RemoteCertificateChainErrors) != 0 && args.Chain is not null)
-			{
-				foreach (var status in args.Chain.ChainStatus)
-				{
-					// Apple-specific error code for incomplete revocation check
-					if (status.Status == X509ChainStatusFlags.RevocationStatusUnknown ||
-						status.Status == X509ChainStatusFlags.OfflineRevocation)
-					{
-						// Optionally log or handle as needed
-						continue; // Ignore this error
-					}
-					if (status.Status != X509ChainStatusFlags.NoError)
-						return false; // Fail on other errors
-				}
-				args.IsValid = true; // Accept certificate
-				return true; // Only revocation check failed, allow
-				
-			}
-
-			return false;
-
-
-		//	ServiceRef.LogService.LogDebug("Result: " + res?.ToString() ?? "null");
-
-			byte[] Cert = args.Certificate?.Export(X509ContentType.Cert);    // Avoids SafeHandle exception when accessing certificate later.
-
-
-			StringBuilder Base64 = new StringBuilder();
-			string s;
-			int c = Cert?.Length ?? 0;
-			int i = 0;
-			int j;
-
-			while (i < c)
-			{
-				j = Math.Min(57, c - i);
-				s = Convert.ToBase64String(Cert, i, j);
-				i += j;
-
-				Base64.Append(s);
-
-				if (i < c)
-					Base64.AppendLine();
-			}
-
-			StringBuilder SniffMsg = new StringBuilder();
-
-			SniffMsg.AppendLine("Invalid certificate received (and rejected).");
-
-			SniffMsg.AppendLine();
-			SniffMsg.Append("sslPolicyErrors: ");
-			SniffMsg.AppendLine(args.SslPolicyErrors.ToString());
-			SniffMsg.Append("Subject: ");
-			SniffMsg.AppendLine(args.Certificate?.Subject);
-			SniffMsg.Append("Issuer: ");
-			SniffMsg.AppendLine(args.Certificate?.Issuer);
-			SniffMsg.Append("BASE64(Cert): ");
-			SniffMsg.Append(Base64);
-			SniffMsg.AppendLine();
-
-			SniffMsg.AppendLine("Nr of elements in chain: ");
-			SniffMsg.Append(args.Chain.ChainElements.Count);
-			SniffMsg.AppendLine();
-			SniffMsg.AppendLine("Chain status: ");
-			foreach (X509ChainStatus Status in args.Chain.ChainStatus)
-			{
-				SniffMsg.Append("Status: ");
-				SniffMsg.AppendLine(Status.Status.ToString());
-				SniffMsg.Append("StatusInformation: ");
-				SniffMsg.AppendLine(Status.StatusInformation);
-				SniffMsg.AppendLine();
-
-			}
-
-			SniffMsg.AppendLine("Chain elements:");
-			foreach (X509ChainElement Element in args.Chain.ChainElements)
-			{
-				SniffMsg.Append("Subject: ");
-				SniffMsg.AppendLine(Element.Certificate.Subject);
-				SniffMsg.Append("Issuer: ");
-				SniffMsg.AppendLine(Element.Certificate.Issuer);
-				SniffMsg.AppendLine("Info: ");
-				SniffMsg.Append(Element.Information);
-				SniffMsg.AppendLine();
-			}
-
-			try
-			{
-				ServiceRef.LogService.LogWarning(SniffMsg.ToString());
-			}
-			catch (Exception ex2)
-			{
-				ServiceRef.LogService.LogException(ex2);
-			}
-			//	X509Certificate? Cert2 = args.Chain.ChainElements.FirstOrDefault()?.Certificate;
-			//	if(Cert2 is not null)
-			//		MyCertValidationCallback(null, new RemoteCertificateEventArgs(Cert2, null, args.SslPolicyErrors));
-
-			return false;
-		}
-		// Inspect args.ServerCertificate, args.Chain, args.PolicyErrors etc.
-		// Return true to accept the cert, false to reject.
-		//return MyOwnLogic(args.ServerCertificate, args.Chain, args.PolicyErrors);
 
 		/// <inheritdoc/>
 		protected override async Task OnInitialize()
@@ -174,8 +43,8 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 					ContentResponse Result = await InternetContent.PostAsync(
 						new Uri("https://" + Constants.Domains.IdDomain + "/ID/CountryCode.ws"),
 						string.Empty,                       // Data
-		//				null,                               // Certificate
-		//				(object? sender, RemoteCertificateEventArgs e) => MyCertValidationCallback(sender, e),          // RemoteCertificateValidator
+						null,                               // Certificate
+						App.ValidateCertificateCallback,          // RemoteCertificateValidator
 						new KeyValuePair<string, string>("Accept", "application/json")  // Headers
 					);
 					Result.AssertOk();
@@ -224,6 +93,8 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 				{
 					ContentResponse Result = await InternetContent.PostAsync(
 						new Uri("https://" + Constants.Domains.IdDomain + "/ID/CountryCode.ws"), string.Empty,
+						null,                               // Certificate
+						App.ValidateCertificateCallback,          // RemoteCertificateValidator
 						new KeyValuePair<string, string>("Accept", "application/json"));
 
 					Result.AssertOk();
@@ -368,7 +239,10 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 						{ "Nr", FullPhoneNumber },
 						{ "AppName", Constants.Application.Name },
 						{ "Language", CultureInfo.CurrentCulture.TwoLetterISOLanguageName }
-					}, new KeyValuePair<string, string>("Accept", "application/json"));
+					},
+					null,                               // Certificate
+					App.ValidateCertificateCallback,          // RemoteCertificateValidator
+					new KeyValuePair<string, string>("Accept", "application/json"));
 
 				SendResult.AssertOk();
 
@@ -406,7 +280,10 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 									{ "Nr", FullPhoneNumber },
 									{ "Code", int.Parse(Code, NumberStyles.None, CultureInfo.InvariantCulture) },
 									{ "Test", IsTest }
-								}, new KeyValuePair<string, string>("Accept", "application/json"));
+								},
+								null,                               // Certificate
+								App.ValidateCertificateCallback,          // RemoteCertificateValidator
+								new KeyValuePair<string, string>("Accept", "application/json"));
 
 							VerifyResult.AssertOk();
 
@@ -503,7 +380,10 @@ namespace NeuroAccessMaui.UI.Pages.Registration.Views
 						{ "Nr", FullPhoneNumber },
 						{ "AppName", Constants.Application.Name },
 						{ "Language", CultureInfo.CurrentCulture.TwoLetterISOLanguageName }
-					}, new KeyValuePair<string, string>("Accept", "application/json"));
+					},
+					null,                               // Certificate
+					App.ValidateCertificateCallback,          // RemoteCertificateValidator
+					new KeyValuePair<string, string>("Accept", "application/json"));
 
 				SendResult.AssertOk();
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.408",
+    "version": "8.0.409",
     "allowPrerelease": false,
     "rollForward": "disable"
   }


### PR DESCRIPTION
This pull request introduces changes to enhance SSL certificate validation, improve logging capabilities, and ensure proper resource disposal in the `NeuroAccessMaui` application. The most significant updates include the addition of a custom SSL certificate validation callback, integration of this callback across various network requests

### SSL Certificate Validation Enhancements:
* Added `ValidateCertificateCallback` method in `App.xaml.cs` to handle SSL certificate validation, addressing incomplete revocation checks on iOS devices and logging rejected certificates for debugging purposes.
* Updated network requests in multiple view models (`ChooseProviderViewModel`, `ContactSupportViewModel`, `FinalizeViewModel`, `ValidateEmailViewModel`, and `ValidatePhoneViewModel`) to use the new `ValidateCertificateCallback` for SSL certificate validation. [[1]](diffhunk://#diff-239589ea6729864da2895d47f9987c3a543d07fecfdb2128437fd409faf1785eR166-R167) [[2]](diffhunk://#diff-0a15c68dfcbeb5f9e5ebe1a6002baf8a570719648f445157a7c53992d46fc1e2L78-R81) [[3]](diffhunk://#diff-0a15c68dfcbeb5f9e5ebe1a6002baf8a570719648f445157a7c53992d46fc1e2L216-R222) [[4]](diffhunk://#diff-b4afcf77e197cf417cea115a71b6498a24fef8586deb1688145f6cd26813aea9L147-R150) [[5]](diffhunk://#diff-dbaeeff56c5b44fb80404a27e1a3a05cabc66e8882ed7728de74271ba9a5ce40L44-R49)

### Logging Improvements:
* Modified the `ILogService` interface to implement `IDisposable`, allowing for proper cleanup of resources.
* Added a `Dispose` method in `LogService` to ensure synchronous cleanup of active debug log sessions and suppress finalization.

