### PR TITLE
Revert transparent QR code

### DIFF
--- a/NeuroAccessMaui/Services/UI/QR/QrCode.cs
+++ b/NeuroAccessMaui/Services/UI/QR/QrCode.cs
@@ -280,9 +280,9 @@ namespace NeuroAccessMaui.Services.UI.QR
 		private static readonly SKColor bgDark = SKColors.Black;          //       fail to decode such codes. You can make it less bright however.
 
 		private static readonly CustomColoring userCodeLight = new(userPath,
-			256, 256, SKColors.Red, SKColors.Transparent, bgLight, SKColors.Transparent,
-			SKColors.DarkRed, SKColors.Red, SKColors.Transparent,
-			SKColors.DarkSlateGray, SKColors.SlateGray, SKColors.Transparent);
+			256, 256, SKColors.Red, fgLight, bgLight, fgLight,
+			SKColors.DarkRed, SKColors.Red, fgLight,
+			SKColors.DarkSlateGray, SKColors.SlateGray, fgLight);
 
 		private static readonly CustomColoring userCodeDark = new(userPath,
 			256, 256, SKColors.Red, fgDark, bgDark, fgDark,

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.409",
+    "version": "8.0.410",
     "allowPrerelease": false,
     "rollForward": "disable"
   }


### PR DESCRIPTION
# Remove transparent background from user QR code

### Sharing a QR code with transparent background caused inconsistency with scanning because of the background in different apps. Forcing the background to white should prevent these issues

<!-- Describe the purpose of your changes. Include any relevant context or motivation. -->

**What kind of change does this PR introduce?**

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactoring
* [ ] Performance improvement

## 🔄 Changelog

### Changed

* Change light-mode QR-code colors from transparent to white
