### PR TITLE
Add support for alternative colors

### DIFF
--- a/Build/color_generator.py
+++ b/Build/color_generator.py
@@ -1,4 +1,5 @@
 import json
+import argparse
 from collections.abc import Generator
 
 """
@@ -46,11 +47,15 @@ xaml_doc_start = """
 
 xaml_doc_end = "</ResourceDictionary>"
 
-def create_xaml_file() -> str:
+def create_xaml_file(alternative: bool) -> str:
     with open("colors.json") as f:
         data = json.load(f)[0]["values"]
-        formatted_light_colors = list(json_color_list_xaml_list(data[0]["color"], False))
-        formatted_dark_colors = list(json_color_list_xaml_list(data[1]["color"], True))
+        if alternative:
+            formatted_light_colors = list(json_color_list_xaml_list(data[3]["color"], False))
+            formatted_dark_colors = list(json_color_list_xaml_list(data[2]["color"], True))
+        else:
+            formatted_light_colors = list(json_color_list_xaml_list(data[0]["color"], False))
+            formatted_dark_colors = list(json_color_list_xaml_list(data[1]["color"], True))
 
     result = "\n".join([xaml_doc_start] + formatted_light_colors + formatted_dark_colors + [xaml_doc_end])
     
@@ -59,7 +64,18 @@ def create_xaml_file() -> str:
 
     return result
 
-result = create_xaml_file()
+
+parser = argparse.ArgumentParser(
+    prog='ColorConverter',
+    description='Converts JSON colors from figma to colors.xaml, usable in a C# MAUI app',
+    epilog='Wow you actually read documentation, good for you. Happy easter (Egg)'
+)
+
+parser.add_argument("-a", "--alternative", action="store_true", help="If flag is set, creates the xaml file used for second light/dark pair of themes")
+
+args = parser.parse_args()
+
+result = create_xaml_file(args.alternative)
 
 # Check if there is a file containing the old colors and print information of what colors have changed
 try:


### PR DESCRIPTION
<!--
Thank you for your contribution! Please fill out the sections below.
-->

# Support alternative colors in color generator

## 📋 Description

<!-- Describe the purpose of your changes. Include any relevant context or motivation. -->

The color generator currently takes a json file with colors divided into Light and Dark mode categories and creates a color.xaml file. For each color it creates `colorLight` and `colorDark`. This approach is limited to two colors. With this PR, we can now have a second, alternative, pair of themes that get used instead, but the colors.xaml file will have the same name on the colors (Only hex values are replaced effectively)

**What kind of change does this PR introduce?**

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactoring
* [ ] Performance improvement
* [ ] Other (please describe): \_\_\_\_\_\_\_\_\_\_

## 🛠️ Implementation Details

<!-- How did you implement these changes? What approach did you take? -->

* Added a command line parser
* Added -a or -alternative as a flag in parser
    * The flag causes the converter to use the second pair of themes in the colors.json file

## 🔄 Changelog

<!-- Please add one-line entries in the appropriate categories. If none apply, remove the category. -->

### Added

* Allow color converter to support a second pair of light/dark themes for the app