### PR TITLE
Update Test navigation service

### DIFF
--- a/NeuroAccessMaui/App.xaml.cs
+++ b/NeuroAccessMaui/App.xaml.cs
@@ -427,8 +427,8 @@ namespace NeuroAccessMaui
 				await ServiceRef.NotificationService.Load(isResuming, Token);
 
 
-				var navigationService = ServiceRef.Provider.GetRequiredService<NavigationService>();
-				await navigationService.NavigateToAsync(nameof(NeuroAccessMaui.UI.Pages.Main.MainPage));
+                                var navigationService = ServiceRef.Provider.GetRequiredService<NavigationService>();
+                                await navigationService.GoToAsync(nameof(NeuroAccessMaui.UI.Pages.Main.MainPage));
 			//	AppShell.AppLoaded();
 			}
 			catch (OperationCanceledException)

--- a/NeuroAccessMaui/Test/INavigationService.cs
+++ b/NeuroAccessMaui/Test/INavigationService.cs
@@ -12,10 +12,25 @@ namespace NeuroAccessMaui.Test
 	{
 
 		/// <summary>
-		/// Navigates to the specified route and pushes the page onto the navigation stack.
-		/// </summary>
-		/// <param name="Route">The route string.</param>
-		Task NavigateToAsync(string Route);
+               /// Navigates to the specified route and pushes the page onto the navigation stack.
+               /// </summary>
+               /// <param name="Route">The route string.</param>
+               Task GoToAsync(string Route);
+
+               /// <summary>
+               /// Navigates to the specified route and pushes the page onto the navigation stack with navigation arguments.
+               /// </summary>
+               /// <typeparam name="TArgs">The navigation arguments type.</typeparam>
+               /// <param name="Route">The route string.</param>
+               /// <param name="Args">Optional navigation arguments.</param>
+               Task GoToAsync<TArgs>(string Route, TArgs? Args)
+                       where TArgs : Services.UI.NavigationArgs, new();
+
+               /// <summary>
+               /// Navigates directly to a page instance.
+               /// </summary>
+               /// <param name="Page">The page to navigate to.</param>
+               Task GoToAsync(ContentPage Page);
 
 		/// <summary>
 		/// Pops the current page from the navigation stack and displays the previous page.
@@ -41,6 +56,13 @@ namespace NeuroAccessMaui.Test
 		/// <summary>
 		/// Gets the current visible page.
 		/// </summary>
-		ContentPage CurrentPage { get; }
-	}
+        ContentPage CurrentPage { get; }
+
+               /// <summary>
+               /// Pops the latest navigation arguments if any.
+               /// </summary>
+               /// <typeparam name="TArgs">The navigation arguments type.</typeparam>
+               /// <returns>Navigation arguments or null.</returns>
+               TArgs? PopLatestArgs<TArgs>() where TArgs : Services.UI.NavigationArgs, new();
+        }
 }

--- a/NeuroAccessMaui/Test/NavigationService.cs
+++ b/NeuroAccessMaui/Test/NavigationService.cs
@@ -1,7 +1,9 @@
 using Microsoft.Maui.Controls;
 using NeuroAccessMaui.Services;
+using NeuroAccessMaui.Services.UI;
 using System.Threading.Tasks;
 using System.Collections.Generic;
+using System.Collections.Concurrent;
 using Waher.Runtime.Inventory;
 
 namespace NeuroAccessMaui.Test
@@ -14,98 +16,171 @@ namespace NeuroAccessMaui.Test
         {
                 private readonly Stack<ContentPage> navigationStack = new();
                 private readonly Stack<ContentPage> modalStack = new();
+                private readonly Stack<NavigationArgs?> navigationArgsStack = new();
 
-		/// <inheritdoc/>
+                private readonly ConcurrentQueue<Func<Task>> taskQueue = new();
+                private bool isExecutingTasks = false;
+                private NavigationArgs? latestArguments = null;
+
+                private Task Enqueue(Func<Task> Action)
+                {
+                        TaskCompletionSource<bool> tcs = new();
+                        this.taskQueue.Enqueue(async () =>
+                        {
+                                try
+                                {
+                                        await Action();
+                                        tcs.TrySetResult(true);
+                                }
+                                catch (Exception ex)
+                                {
+                                        tcs.TrySetException(ex);
+                                }
+                        });
+
+                        if (!this.isExecutingTasks)
+                        {
+                                this.isExecutingTasks = true;
+                                MainThread.BeginInvokeOnMainThread(async () =>
+                                {
+                                        await this.ProcessQueue();
+                                });
+                        }
+
+                        return tcs.Task;
+                }
+
+                private async Task ProcessQueue()
+                {
+                        try
+                        {
+                                while (this.taskQueue.TryDequeue(out Func<Task>? action))
+                                {
+                                        await MainThread.InvokeOnMainThreadAsync(action);
+                                }
+                        }
+                        finally
+                        {
+                                this.isExecutingTasks = false;
+                        }
+                }
+
+                /// <inheritdoc/>
                 public ContentPage CurrentPage => this.navigationStack.Count > 0 ? this.navigationStack.Peek() : null;
 
                 /// <inheritdoc/>
                 public ContentPage CurrentModalPage => this.modalStack.Count > 0 ? this.modalStack.Peek() : null;
 
-		/// <inheritdoc/>
-		public async Task NavigateToAsync(string Route)
-		{
-			// Set in your CustomShell
-			await MainThread.InvokeOnMainThreadAsync(async () =>
-			{
-				var page = Routing.GetOrCreateContent(Route, ServiceRef.Provider) as ContentPage;
-				if (page is null)
-					throw new InvalidOperationException($"No page registered for route '{Route}'.");
-
-				this.navigationStack.Push(page);
-				if (Application.Current.MainPage is CustomShell customShell)
-				{
-					await customShell.SetPageAsync(page);
-				}
-				else
-				{
-					// Fallback for testing without CustomShell
-					Application.Current.MainPage = page;
-				}
-			});
-		}
-
-		/// <inheritdoc/>
-                public async Task GoBackAsync()
+                /// <inheritdoc/>
+                public Task GoToAsync(string Route)
                 {
-                        if (this.navigationStack.Count > 1)
-                        {
-				// Pop current
-				this.navigationStack.Pop();
-				var previous = this.navigationStack.Peek();
-
-				await MainThread.InvokeOnMainThreadAsync(async () =>
-				{
-					if (Application.Current.MainPage is CustomShell customShell)
-					{
-						await customShell.SetPageAsync(previous);
-					}
-					else
-					{
-						Application.Current.MainPage = previous;
-					}
-                                });
-                        }
+                        return this.GoToAsync<NavigationArgs>(Route, null);
                 }
 
                 /// <inheritdoc/>
-                public async Task PushModalAsync(string Route)
+                public Task GoToAsync<TArgs>(string Route, TArgs? Args)
+                        where TArgs : NavigationArgs, new()
                 {
-                        await MainThread.InvokeOnMainThreadAsync(async () =>
+                        return this.Enqueue(async () =>
+                        {
+                                var page = Routing.GetOrCreateContent(Route, ServiceRef.Provider) as ContentPage;
+                                if (page is null)
+                                        throw new InvalidOperationException($"No page registered for route '{Route}'.");
+
+                                NavigationArgs navigationArgs = Args ?? new();
+                                navigationArgs.SetBackArguments(this.navigationArgsStack.Count > 0 ? this.navigationArgsStack.Peek() : null);
+
+                                this.latestArguments = navigationArgs;
+                                this.navigationArgsStack.Push(navigationArgs);
+                                this.navigationStack.Push(page);
+
+                                if (Application.Current.MainPage is CustomShell customShell)
+                                        await customShell.SetPageAsync(page);
+                                else
+                                        Application.Current.MainPage = page;
+                        });
+                }
+
+                /// <inheritdoc/>
+                public Task GoToAsync(ContentPage Page)
+                {
+                        return this.Enqueue(async () =>
+                        {
+                                this.latestArguments = null;
+                                this.navigationArgsStack.Push(null);
+                                this.navigationStack.Push(Page);
+
+                                if (Application.Current.MainPage is CustomShell customShell)
+                                        await customShell.SetPageAsync(Page);
+                                else
+                                        Application.Current.MainPage = Page;
+                        });
+                }
+
+		/// <inheritdoc/>
+                public Task GoBackAsync()
+                {
+                        return this.Enqueue(async () =>
+                        {
+                                if (this.navigationStack.Count > 1)
+                                {
+                                        this.navigationStack.Pop();
+                                        this.navigationArgsStack.Pop();
+                                        var previous = this.navigationStack.Peek();
+
+                                        if (Application.Current.MainPage is CustomShell customShell)
+                                                await customShell.SetPageAsync(previous);
+                                        else
+                                                Application.Current.MainPage = previous;
+                                }
+                        });
+                }
+
+                /// <inheritdoc/>
+                public Task PushModalAsync(string Route)
+                {
+                        return this.Enqueue(async () =>
                         {
                                 var page = Routing.GetOrCreateContent(Route, ServiceRef.Provider) as ContentPage;
                                 if (page is null)
                                         throw new InvalidOperationException($"No page registered for route '{Route}'.");
 
                                 this.modalStack.Push(page);
+
                                 if (Application.Current.MainPage is CustomShell customShell)
-                                {
                                         await customShell.PushModalAsync(page);
-                                }
                                 else
-                                {
                                         await Application.Current.MainPage.Navigation.PushModalAsync(page);
-                                }
                         });
                 }
 
                 /// <inheritdoc/>
-                public async Task PopModalAsync()
+                public Task PopModalAsync()
                 {
-                        if (this.modalStack.Count == 0)
-                                return;
-
-                        this.modalStack.Pop();
-                        await MainThread.InvokeOnMainThreadAsync(async () =>
+                        return this.Enqueue(async () =>
                         {
+                                if (this.modalStack.Count == 0)
+                                        return;
+
+                                this.modalStack.Pop();
+
                                 if (Application.Current.MainPage is CustomShell customShell)
-                                {
                                         await customShell.PopModalAsync();
-                                }
                                 else
-                                {
                                         await Application.Current.MainPage.Navigation.PopModalAsync();
-                                }
                         });
+                }
+
+                /// <inheritdoc/>
+                public TArgs? PopLatestArgs<TArgs>() where TArgs : NavigationArgs, new()
+                {
+                        if (this.latestArguments is TArgs args)
+                        {
+                                this.latestArguments = null;
+                                return args;
+                        }
+
+                        return null;
                 }
         }
 }

--- a/NeuroAccessMaui/UI/Pages/Main/MainViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Main/MainViewModel.cs
@@ -145,7 +145,7 @@ namespace NeuroAccessMaui.UI.Pages.Main
 		{
 			try
 			{
-				await ServiceRef.Provider.GetRequiredService<INavigationService>().NavigateToAsync(nameof(ViewIdentityPage));
+                                await ServiceRef.Provider.GetRequiredService<INavigationService>().GoToAsync(nameof(ViewIdentityPage));
 
 				if (await this.authenticationService.AuthenticateUserAsync(AuthenticationPurpose.ViewId))
 					await ServiceRef.UiService.GoToAsync(nameof(ViewIdentityPage));


### PR DESCRIPTION
## Summary
- rename `NavigateToAsync` to `GoToAsync`
- overload `GoToAsync` for a `ContentPage` parameter
- queue navigation tasks to serialize UI actions
- add `NavigationArgs` support and expose `PopLatestArgs`
- update startup and view model code to use the new API

## Testing
- `dotnet build NeuroAccessMaui/NeuroAccessMaui.sln -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686c3dfc1598832da9d1168dde60062d