### PR TITLE
Settings scroll

### DIFF
--- a/NeuroAccessMaui/UI/Pages/Main/Settings/SettingsPage.xaml
+++ b/NeuroAccessMaui/UI/Pages/Main/Settings/SettingsPage.xaml
@@ -12,28 +12,28 @@
 							 xmlns:converters="clr-namespace:NeuroAccessMaui.UI.Converters"
 							 xmlns:viewmodel="clr-namespace:NeuroAccessMaui.UI.Pages.Main.Settings">
 
-	<Grid BackgroundColor="{DynamicResource SurfaceBackgroundWL}">
+	<Grid BackgroundColor="{DynamicResource SurfaceBackgroundWL}" RowDefinitions="auto, *">
 
-		<controls:Background/>
+		<controls:Background Grid.RowSpan="2"/>
 
-		<ScrollView>
-			<VerticalStackLayout Margin="{DynamicResource SmallMargins}">
-				<Grid ColumnDefinitions="Auto, *" Margin="{DynamicResource SmallMargins}">
-					<controls:SvgButton
-						Grid.Row="0" Grid.Column="0"
-						Command="{Binding GoBackCommand}"
-						SvgSource="close.svg"
-						Style="{DynamicResource IconButton}"/>
+		<Grid ColumnDefinitions="Auto, *" Margin="{DynamicResource MediumMargins}">
+			<controls:SvgButton
+				HeightRequest="40"
+				Command="{Binding GoBackCommand}"
+				SvgSource="close.svg"
+				Style="{DynamicResource IconButton}"/>
 
-					<Label
-						Grid.Column="1"
-						HorizontalOptions="End"
-						Style="{DynamicResource PageTitleLabel}"
-						Text="{l:Localize Settings}"/>
-				</Grid>
+			<Label
+				Grid.Column="1"
+				HorizontalOptions="End"
+				Style="{DynamicResource PageTitleLabel}"
+				Text="{l:Localize Settings}"/>
+		</Grid>
 				
+		<ScrollView Grid.Row="1">
+			<VerticalStackLayout Margin="{DynamicResource SmallLeftRightBottomMargins}">
 				<!-- Display Settings -->
-				<Border Style="{DynamicResource BorderSet}">
+				<Border Style="{DynamicResource BorderSet}" Margin="{DynamicResource SmallLeftRightBottomMargins}">
 					<VerticalStackLayout Spacing="{DynamicResource SmallSpacing}">
 						<Label Style="{DynamicResource SectionTitleLabel}" Text="{l:Localize DisplaySettings}"/>
 


### PR DESCRIPTION
<!--
Thank you for your contribution! Please fill out the sections below.
-->

# Settings scroll

## 📋 Description

Ensures the title label and back button are outside the scrollview so that you can exit settings without scrolling back up

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactoring
* [ ] Performance improvement

## 🔄 Changelog

<!-- Please add one-line entries in the appropriate categories. If none apply, remove the category. -->

### Changed

* Change settings menu so back button is always visible
