### PR TITLE
Ensure XMPP is connected before opening ViewID page

### DIFF
--- a/NeuroAccessMaui/UI/Pages/Main/Apps/AppsViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Main/Apps/AppsViewModel.cs
@@ -154,7 +154,10 @@ namespace NeuroAccessMaui.UI.Pages.Main.Apps
 			try
 			{
 				if (await App.AuthenticateUserAsync(AuthenticationPurpose.ViewId))
+				{
+					await ServiceRef.XmppService.WaitForConnectedState(Constants.Timeouts.XmppConnect);
 					await ServiceRef.UiService.GoToAsync(nameof(ViewIdentityPage));
+				}
 			}
 			catch (Exception Ex)
 			{

--- a/NeuroAccessMaui/UI/Pages/Main/MainViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Main/MainViewModel.cs
@@ -143,7 +143,10 @@ namespace NeuroAccessMaui.UI.Pages.Main
 			try
 			{
 				if(await App.AuthenticateUserAsync(AuthenticationPurpose.ViewId))
+				{
+					await ServiceRef.XmppService.WaitForConnectedState(Constants.Timeouts.XmppConnect);
 					await ServiceRef.UiService.GoToAsync(nameof(ViewIdentityPage));
+				}
 			}
 			catch (Exception Ex)
 			{


### PR DESCRIPTION
<!--
Thank you for your contribution! Please fill out the sections below.
-->

# Await XMPP connection before opening ViewID page

## 📋 Description

<!-- Describe the purpose of your changes. Include any relevant context or motivation. -->

Adds quick check before opening ViewIDPage to ensure XMPP is connected before opening the page. This prevents a major error from occuring when loading images.

* [x] Bug fix
* [ ] New feature
* [ ] Documentation update
* [ ] Refactoring
* [ ] Performance improvement
* [ ] Other (please describe): \_\_\_\_\_\_\_\_\_\_

## 🔄 Changelog

### Fixed

* Fixed connection bug when opening ID page