### PR TITLE
Fix broken rendering of token reports

### DIFF
--- a/NeuroAccessMaui/Extensions/StringExtensions.cs
+++ b/NeuroAccessMaui/Extensions/StringExtensions.cs
@@ -88,6 +88,35 @@ namespace NeuroAccessMaui.Extensions
 		}
 
 		/// <summary>
+		/// Converts Markdown text to Maui
+		/// </summary>
+		public static async Task<VerticalStackLayout> MarkdownToMaui(this string Markdown)
+		{
+			MarkdownSettings Settings = new()
+			{
+				AllowScriptTag = false,
+				EmbedEmojis = false,    // TODO: Emojis
+				AudioAutoplay = false,
+				AudioControls = false,
+				ParseMetaData = false,
+				VideoAutoplay = false,
+				VideoControls = false
+			};
+
+			MarkdownDocument Doc = await MarkdownDocument.CreateAsync(Markdown, Settings);
+
+			using MauiRenderer Renderer = new(Doc);
+			await Doc.RenderDocument(Renderer);
+
+			VerticalStackLayout? Layout = Renderer.Output();
+
+			if (Layout is null)
+				return new VerticalStackLayout();
+
+			return Layout;
+		}
+
+		/// <summary>
 		/// Converts Markdown text to Maui XAML
 		/// </summary>
 		/// <param name="Markdown">Markdown</param>

--- a/NeuroAccessMaui/Services/Xmpp/IXmppService.cs
+++ b/NeuroAccessMaui/Services/Xmpp/IXmppService.cs
@@ -1602,10 +1602,22 @@ namespace NeuroAccessMaui.Services.Xmpp
 		Task<string> GenerateNeuroFeatureStateDiagramReport(string TokenId);
 
 		/// <summary>
+		/// Generates a MAUI report for a state diagram corresponding to the token.
+		/// </summary>
+		/// <returns>String-representation of MAUI of report.</returns>
+		Task<VerticalStackLayout> GenerateNeuroFeatureStateDiagramReportMaui(string TokenId);
+
+		/// <summary>
 		/// Generates a XAML report for a timing diagram corresponding to the token.
 		/// </summary>
 		/// <returns>String-representation of XAML of report.</returns>
 		Task<string> GenerateNeuroFeatureProfilingReport(string TokenId);
+
+		/// <summary>
+		/// Generates a Maui report for a timing diagram corresponding to the token.
+		/// </summary>
+		/// <returns>String-representation of Maui of report.</returns>
+		Task<VerticalStackLayout> GenerateNeuroFeatureProfilingReportMaui(string TokenId);
 
 		/// <summary>
 		/// Generates a XAML present report for a token.
@@ -1614,10 +1626,20 @@ namespace NeuroAccessMaui.Services.Xmpp
 		Task<string> GenerateNeuroFeaturePresentReport(string TokenId);
 
 		/// <summary>
+		/// Generates a MAUI present report for a token.
+		/// </summary>
+		Task<VerticalStackLayout> GenerateNeuroFeaturePresentReportMaui(string TokenId);
+
+		/// <summary>
 		/// Generates a XAML history report for a token.
 		/// </summary>
 		/// <returns>String-representation of XAML of report.</returns>
 		Task<string> GenerateNeuroFeatureHistoryReport(string TokenId);
+
+		/// <summary>
+		/// Generates a MAUI history report for a token.
+		/// </summary>
+		Task<VerticalStackLayout> GenerateNeuroFeatureHistoryReportMaui(string TokenId);
 
 		/// <summary>
 		/// Gets the current state of a Neuro-Feature token.

--- a/NeuroAccessMaui/Services/Xmpp/XmppService.cs
+++ b/NeuroAccessMaui/Services/Xmpp/XmppService.cs
@@ -5702,6 +5702,19 @@ namespace NeuroAccessMaui.Services.Xmpp
 		}
 
 		/// <summary>
+		/// Generates a Maui report for a state diagram corresponding to the token.
+		/// </summary>
+		/// <returns>String-representation of XAML of report.</returns>
+		public async Task<VerticalStackLayout> GenerateNeuroFeatureStateDiagramReportMaui(string TokenId)
+		{
+			ReportEventArgs e = await this.NeuroFeaturesClient.GenerateStateDiagramAsync(TokenId, ReportFormat.Markdown);
+			if (!e.Ok)
+				throw e.StanzaError ?? new Exception(ServiceRef.Localizer[nameof(AppResources.UnableToGetStateDiagram)]);
+
+			return await e.ReportText.MarkdownToMaui();
+		}
+
+		/// <summary>
 		/// Generates a XAML report for a timing diagram corresponding to the token.
 		/// </summary>
 		/// <returns>String-representation of XAML of report.</returns>
@@ -5712,6 +5725,19 @@ namespace NeuroAccessMaui.Services.Xmpp
 				throw e.StanzaError ?? new Exception(ServiceRef.Localizer[nameof(AppResources.UnableToGetProfiling)]);
 
 			return await e.ReportText.MarkdownToXaml();
+		}
+
+		/// <summary>
+		/// Generates a Maui report for a timing diagram corresponding to the token.
+		/// </summary>
+		/// <returns>String-representation of XAML of report.</returns>
+		public async Task<VerticalStackLayout> GenerateNeuroFeatureProfilingReportMaui(string TokenId)
+		{
+			ReportEventArgs e = await this.NeuroFeaturesClient.GenerateProfilingReportAsync(TokenId, ReportFormat.Markdown);
+			if (!e.Ok)
+				throw e.StanzaError ?? new Exception(ServiceRef.Localizer[nameof(AppResources.UnableToGetProfiling)]);
+
+			return await e.ReportText.MarkdownToMaui();
 		}
 
 		/// <summary>
@@ -5728,6 +5754,19 @@ namespace NeuroAccessMaui.Services.Xmpp
 		}
 
 		/// <summary>
+		/// Generates a MAUI present report for a token.
+		/// </summary>
+		/// <returns>String-representation of XAML of report.</returns>
+		public async Task<VerticalStackLayout> GenerateNeuroFeaturePresentReportMaui(string TokenId)
+		{
+			ReportEventArgs e = await this.NeuroFeaturesClient.GeneratePresentReportAsync(TokenId, ReportFormat.Markdown);
+			if (!e.Ok)
+				throw e.StanzaError ?? new Exception(ServiceRef.Localizer[nameof(AppResources.UnableToGetPresent)]);
+
+			return await e.ReportText.MarkdownToMaui();
+		}
+
+		/// <summary>
 		/// Generates a XAML history report for a token.
 		/// </summary>
 		/// <returns>String-representation of XAML of report.</returns>
@@ -5739,6 +5778,19 @@ namespace NeuroAccessMaui.Services.Xmpp
 
 			return await e.ReportText.MarkdownToXaml();
 		}
+
+		/// <summary>
+		/// Generates a MAUI history report for a token.
+		/// </summary>
+		public async Task<VerticalStackLayout> GenerateNeuroFeatureHistoryReportMaui(string TokenId)
+		{
+			ReportEventArgs e = await this.NeuroFeaturesClient.GenerateHistoryReportAsync(TokenId, ReportFormat.Markdown);
+			if (!e.Ok)
+				throw e.StanzaError ?? new Exception(ServiceRef.Localizer[nameof(AppResources.UnableToGetHistory)]);
+
+			return await e.ReportText.MarkdownToMaui();
+		}
+
 
 		/// <summary>
 		/// Gets the current state of a Neuro-Feature token.

--- a/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/MachineReportPage.xaml
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/MachineReportPage.xaml
@@ -11,17 +11,19 @@
 							 xmlns:controls="clr-namespace:NeuroAccessMaui.UI.Controls"
 							 xmlns:converters="clr-namespace:NeuroAccessMaui.UI.Converters"
 							 xmlns:viewmodel="clr-namespace:NeuroAccessMaui.UI.Pages.Wallet.MachineReport">
-	<Grid BackgroundColor="{DynamicResource SurfaceBackgroundWL}">
+	<Grid BackgroundColor="{DynamicResource SurfaceBackgroundWL}" RowDefinitions="auto, *">
 
-		<controls:Background/>
+		<controls:Background Grid.RowSpan="2"/>
 
-		<ScrollView>
-			<VerticalStackLayout Spacing="{DynamicResource SmallSpacing}" Margin="{DynamicResource MediumSpacing}">
-				<controls:ImageButton HorizontalOptions="Start" Command="{Binding GoBackCommand}"
-											 Style="{DynamicResource ImageOnlyButton}" PathData="{x:Static ui:Geometries.BackButtonPath}" />
+		<Grid ColumnDefinitions="auto, *, auto" Margin="16,8,16,8">
+			<controls:SvgButton HorizontalOptions="Start" Command="{Binding GoBackCommand}"
+								Style="{DynamicResource IconButton}" SvgSource="close.svg" />
 
-				<Label Text="{Binding Title}" Style="{DynamicResource PageTitleLabel}"/>
-
+			<Label Grid.Column="2" Text="{Binding Title}" Style="{DynamicResource PageTitleLabel}"/>
+		</Grid>
+		
+		<ScrollView Grid.Row="1">
+			<VerticalStackLayout Spacing="{DynamicResource SmallSpacing}">
 				<Border Style="{DynamicResource BorderSet}">
 					<VerticalStackLayout Spacing="{DynamicResource LargeSpacing}">
 						<ContentView Content="{Binding Report}"/>

--- a/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/MachineReportPage.xaml
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/MachineReportPage.xaml
@@ -21,15 +21,22 @@
 
 			<Label Grid.Column="2" Text="{Binding Title}" Style="{DynamicResource PageTitleLabel}"/>
 		</Grid>
-		
-		<ScrollView Grid.Row="1">
-			<VerticalStackLayout Spacing="{DynamicResource SmallSpacing}">
-				<Border Style="{DynamicResource BorderSet}">
-					<VerticalStackLayout Spacing="{DynamicResource LargeSpacing}">
-						<ContentView Content="{Binding Report}"/>
+
+		<controls:ConditionView Grid.Row="1" Condition="{Binding Loaded}">
+			<controls:ConditionView.False>
+				<ActivityIndicator IsRunning="True" Color="{DynamicResource PrimaryWL}" HorizontalOptions="Center" VerticalOptions="Center"/>
+			</controls:ConditionView.False>
+			<controls:ConditionView.True>
+				<ScrollView>
+					<VerticalStackLayout Spacing="{DynamicResource SmallSpacing}">
+						<Border Style="{DynamicResource BorderSet}">
+							<VerticalStackLayout Spacing="{DynamicResource LargeSpacing}">
+								<ContentView Content="{Binding Report}"/>
+							</VerticalStackLayout>
+						</Border>
 					</VerticalStackLayout>
-				</Border>
-			</VerticalStackLayout>
-		</ScrollView>
+				</ScrollView>
+			</controls:ConditionView.True>
+		</controls:ConditionView>
 	</Grid>
 </base:BaseContentPage>

--- a/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/MachineReportViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/MachineReportViewModel.cs
@@ -11,6 +11,9 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MachineReport
 	{
 		private bool isDisposed;
 
+		[ObservableProperty]
+		private bool loaded = false;
+
 		/// <summary>
 		/// The view model to bind to for when displaying information about the current state of a state-machine.
 		/// </summary>
@@ -19,6 +22,7 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MachineReport
 			: base()
 		{
 			this.TokenReport = Args?.Report;
+			this.Loaded = false;
 		}
 
 		/// <inheritdoc/>
@@ -34,6 +38,9 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MachineReport
 
 				await this.TokenReport.GenerateReportMaui(this);
 				//await this.TokenReport.GenerateReport(this);
+
+				MainThread.BeginInvokeOnMainThread(() =>
+					this.Loaded = true);
 			}
 
 			ServiceRef.XmppService.NeuroFeatureVariablesUpdated += this.Wallet_VariablesUpdated;

--- a/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/MachineReportViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/MachineReportViewModel.cs
@@ -31,7 +31,9 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MachineReport
 			else
 			{
 				this.Title = await this.TokenReport.GetTitle();
-				await this.TokenReport.GenerateReport(this);
+
+				await this.TokenReport.GenerateReportMaui(this);
+				//await this.TokenReport.GenerateReport(this);
 			}
 
 			ServiceRef.XmppService.NeuroFeatureVariablesUpdated += this.Wallet_VariablesUpdated;

--- a/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/Reports/TokenHistoryReport.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/Reports/TokenHistoryReport.cs
@@ -23,5 +23,10 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MachineReport.Reports
 		{
 			return ServiceRef.XmppService.GenerateNeuroFeatureHistoryReport(this.TokenId);
 		}
+
+		public override Task<VerticalStackLayout> GetReportMaui()
+		{
+			return ServiceRef.XmppService.GenerateNeuroFeatureHistoryReportMaui(this.TokenId);
+		}
 	}
 }

--- a/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/Reports/TokenPresentReport.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/Reports/TokenPresentReport.cs
@@ -23,5 +23,14 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MachineReport.Reports
 		{
 			return ServiceRef.XmppService.GenerateNeuroFeaturePresentReport(this.TokenId);
 		}
+
+		/// <summary>
+		/// Gets the MAUI representation of the report.
+		/// </summary>
+		/// <returns>MAUI representation of report.</returns>
+		public override Task<VerticalStackLayout> GetReportMaui()
+		{
+			return ServiceRef.XmppService.GenerateNeuroFeaturePresentReportMaui(this.TokenId);
+		}
 	}
 }

--- a/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/Reports/TokenProfilingReport.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/Reports/TokenProfilingReport.cs
@@ -23,5 +23,14 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MachineReport.Reports
 		{
 			return ServiceRef.XmppService.GenerateNeuroFeatureProfilingReport(this.TokenId);
 		}
+
+		/// <summary>
+		/// Gets the MAUI representation of the report.
+		/// </summary>
+		/// <returns>MAUI representation of the report.</returns>
+		public override Task<VerticalStackLayout> GetReportMaui()
+		{
+			return ServiceRef.XmppService.GenerateNeuroFeatureProfilingReportMaui(this.TokenId);
+		}
 	}
 }

--- a/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/Reports/TokenReport.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/Reports/TokenReport.cs
@@ -40,6 +40,12 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MachineReport.Reports
 		public abstract Task<string> GetReportXaml();
 
 		/// <summary>
+		/// Gets the MAUI representation of the report.
+		/// </summary>
+		/// <returns>MAUI representation of report.</returns>
+		public abstract Task<VerticalStackLayout> GetReportMaui();
+
+		/// <summary>
 		/// Parses report XAML
 		/// </summary>
 		/// <param name="Xaml">String-representation of XAML</param>
@@ -229,6 +235,26 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MachineReport.Reports
 					{
 						this.temporaryFiles.AddRange(TempFiles);
 					}
+				}
+				catch (Exception ex)
+				{
+					await ServiceRef.UiService.DisplayException(ex);
+				}
+			});
+		}
+
+		/// <summary>
+		/// Generates the report using the new custom MAUI renderer.
+		/// </summary>
+		public async Task GenerateReportMaui(MachineReportViewModel ReportView)
+		{
+			this.view = ReportView;
+			VerticalStackLayout MauiContent = await this.GetReportMaui();
+			MainThread.BeginInvokeOnMainThread(async () =>
+			{
+				try
+				{
+					this.view.Report = MauiContent;
 				}
 				catch (Exception ex)
 				{

--- a/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/Reports/TokenStateDiagramReport.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MachineReport/Reports/TokenStateDiagramReport.cs
@@ -23,5 +23,14 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MachineReport.Reports
 		{
 			return ServiceRef.XmppService.GenerateNeuroFeatureStateDiagramReport(this.TokenId);
 		}
+
+		/// <summary>
+		/// Gets the MAUI representation of the report.
+		/// </summary>
+		/// <returns>MAUI representation of the report.</returns>
+		public override Task<VerticalStackLayout> GetReportMaui()
+		{
+			return ServiceRef.XmppService.GenerateNeuroFeatureStateDiagramReportMaui(this.TokenId);
+		}
 	}
 }

--- a/NeuroAccessMaui/UI/Pages/Wallet/MyTokens/MyTokensPage.xaml
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MyTokens/MyTokensPage.xaml
@@ -14,7 +14,7 @@
 							 xmlns:viewmodel="clr-namespace:NeuroAccessMaui.UI.Pages.Wallet.MyTokens">
 	<Grid BackgroundColor="{DynamicResource SurfaceBackgroundWL}" RowDefinitions="auto,*">
 		<!-- Top Bar -->
-		<Grid ColumnDefinitions="auto,*" Margin="16,8,16,8" RowSpacing="0" ColumnSpacing="8">
+		<Grid ColumnDefinitions="auto,*" Margin="16,8,16,16" RowSpacing="0" ColumnSpacing="8">
 			<controls:SvgButton Grid.Column="0"
 								HorizontalOptions="Start"
 								Command="{Binding GoBackCommand}"

--- a/NeuroAccessMaui/UI/Pages/Wallet/TokenDetails/TokenDetailsPage.xaml
+++ b/NeuroAccessMaui/UI/Pages/Wallet/TokenDetails/TokenDetailsPage.xaml
@@ -118,7 +118,7 @@
                        WidthRequest="{Binding Path=QrCodeWidth, Mode=OneTime}" HeightRequest="{Binding Path=QrCodeHeight, Mode=OneTime}" 
                        VerticalOptions="Start" HorizontalOptions="Center" Margin="{DynamicResource SmallTopMargins}" />
 
-							<VerticalStackLayout IsVisible="False">
+							<VerticalStackLayout>
 								<Label Text="{l:Localize Reports}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"
 										 IsVisible="{Binding HasStateMachine}"/>
 

--- a/NeuroAccessMaui/UI/Pages/Wallet/TokenDetails/TokenDetailsPage.xaml
+++ b/NeuroAccessMaui/UI/Pages/Wallet/TokenDetails/TokenDetailsPage.xaml
@@ -15,324 +15,327 @@
 
 		<controls:Background/>
 
-		<ScrollView>
-			<VerticalStackLayout Spacing="{DynamicResource SmallSpacing}" Margin="{DynamicResource MediumSpacing}">
-				<controls:ImageButton HorizontalOptions="Start" Command="{Binding GoBackCommand}"
-											 Style="{DynamicResource ImageOnlyButton}" PathData="{x:Static ui:Geometries.BackButtonPath}" />
+		<Grid RowDefinitions="auto,*" Margin="8">
+			<Grid ColumnDefinitions="auto, *, auto" Margin="8,0,8,8">
+				<controls:SvgButton HorizontalOptions="Start" Command="{Binding GoBackCommand}"
+									Style="{DynamicResource IconButton}" SvgSource="close.svg" />
 
-				<Label Text="{l:Localize TokenDetails}" Style="{DynamicResource PageTitleLabel}"/>
+				<Label Grid.Column="2" Text="{l:Localize TokenDetails}" Style="{DynamicResource PageTitleLabel}"/>
+			</Grid>
+			<ScrollView Grid.Row="1">
+				<VerticalStackLayout Spacing="{DynamicResource SmallSpacing}">
+					<Border Style="{DynamicResource BorderSet}">
+						<VerticalStackLayout Spacing="{DynamicResource LargeSpacing}">
+							<VerticalStackLayout Margin="{DynamicResource SmallMargins}">
+								<Label Text="{l:Localize TokenDetails}" Margin="{DynamicResource SmallTopMargins}"
+										 VerticalOptions="Start"/>
+								<Label Text="{l:Localize TokenDetailsDescription}" Style="{DynamicResource InfoLabel}" VerticalOptions="Start"/>
+								<Label Text="{l:Localize Description}" Margin="{DynamicResource SmallTopMargins}"
+										 VerticalOptions="Start"/>
+								<ContentView Content="{Binding Description}" VerticalOptions="Start" Margin="{DynamicResource SmallLeftRightBottomMargins}"/>
+								<Grid x:Name="GeneralInfoGrid">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="*"/>
+										<ColumnDefinition Width="*"/>
+									</Grid.ColumnDefinitions>
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+									</Grid.RowDefinitions>
 
-				<Border Style="{DynamicResource BorderSet}">
-					<VerticalStackLayout Spacing="{DynamicResource LargeSpacing}">
-						<VerticalStackLayout Margin="{DynamicResource SmallMargins}">
-							<Label Text="{l:Localize TokenDetails}" Margin="{DynamicResource SmallTopMargins}"
-									 VerticalOptions="Start"/>
-							<Label Text="{l:Localize TokenDetailsDescription}" Style="{DynamicResource InfoLabel}" VerticalOptions="Start"/>
-							<Label Text="{l:Localize Description}" Margin="{DynamicResource SmallTopMargins}"
-									 VerticalOptions="Start"/>
-							<ContentView Content="{Binding Description}" VerticalOptions="Start" Margin="{DynamicResource SmallLeftRightBottomMargins}"/>
-							<Grid x:Name="GeneralInfoGrid">
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*"/>
-									<ColumnDefinition Width="*"/>
-								</Grid.ColumnDefinitions>
-								<Grid.RowDefinitions>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-								</Grid.RowDefinitions>
+									<Label Grid.Column="0" Grid.Row="0" Text="{l:Localize Name}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="0" Text="{Binding FriendlyName}" Style="{DynamicResource ValueLabel}"/>
 
-								<Label Grid.Column="0" Grid.Row="0" Text="{l:Localize Name}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="0" Text="{Binding FriendlyName}" Style="{DynamicResource ValueLabel}"/>
+									<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Category}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="1" Text="{Binding Category}" Style="{DynamicResource ValueLabel}"/>
 
-								<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Category}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="1" Text="{Binding Category}" Style="{DynamicResource ValueLabel}"/>
+									<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize TokenId}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="2" Text="{Binding TokenId}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding TokenId}" />
+										</Label.GestureRecognizers>
+									</Label>
 
-								<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize TokenId}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="2" Text="{Binding TokenId}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding TokenId}" />
-									</Label.GestureRecognizers>
-								</Label>
+									<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize ShortId}" Style="{DynamicResource KeyLabel}"
+											 IsVisible="{Binding HasShortTokenId}"/>
+									<Label Grid.Column="1" Grid.Row="3" Text="{Binding ShortTokenId}" Style="{DynamicResource ClickableValueLabel}"
+											 IsVisible="{Binding HasShortTokenId}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding ShortTokenId}" />
+										</Label.GestureRecognizers>
+									</Label>
 
-								<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize ShortId}" Style="{DynamicResource KeyLabel}"
-										 IsVisible="{Binding HasShortTokenId}"/>
-								<Label Grid.Column="1" Grid.Row="3" Text="{Binding ShortTokenId}" Style="{DynamicResource ClickableValueLabel}"
-										 IsVisible="{Binding HasShortTokenId}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding ShortTokenId}" />
-									</Label.GestureRecognizers>
-								</Label>
+									<Label Grid.Column="0" Grid.Row="4" Text="{l:Localize TokenIdMethod}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="4" Text="{Binding TokenIdMethod}" Style="{DynamicResource ValueLabel}"/>
 
-								<Label Grid.Column="0" Grid.Row="4" Text="{l:Localize TokenIdMethod}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="4" Text="{Binding TokenIdMethod}" Style="{DynamicResource ValueLabel}"/>
+									<Label Grid.Column="0" Grid.Row="5" Text="{l:Localize TokenVisibility}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="5" Text="{Binding Visibility, Converter={converters:LocalizedState}}" Style="{DynamicResource ValueLabel}"/>
 
-								<Label Grid.Column="0" Grid.Row="5" Text="{l:Localize TokenVisibility}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="5" Text="{Binding Visibility, Converter={converters:LocalizedState}}" Style="{DynamicResource ValueLabel}"/>
+									<Label Grid.Column="0" Grid.Row="6" Text="{l:Localize Ordinal}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="6" Style="{DynamicResource ValueLabel}">
+										<Label.FormattedText>
+											<FormattedString>
+												<Span Text="{Binding Ordinal}"/>
+												<Span Text=" of "/>
+												<Span Text="{Binding BatchSize}"/>
+											</FormattedString>
+										</Label.FormattedText>
+									</Label>
 
-								<Label Grid.Column="0" Grid.Row="6" Text="{l:Localize Ordinal}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="6" Style="{DynamicResource ValueLabel}">
-									<Label.FormattedText>
-										<FormattedString>
-											<Span Text="{Binding Ordinal}"/>
-											<Span Text=" of "/>
-											<Span Text="{Binding BatchSize}"/>
-										</FormattedString>
-									</Label.FormattedText>
-								</Label>
+									<Label Grid.Column="0" Grid.Row="7" Text="{l:Localize Valuation}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="7" Style="{DynamicResource ValueLabel}">
+										<Label.FormattedText>
+											<FormattedString>
+												<Span Text="{Binding Value}"/>
+												<Span Text=" "/>
+												<Span Text="{Binding Currency}"/>
+											</FormattedString>
+										</Label.FormattedText>
+									</Label>
 
-								<Label Grid.Column="0" Grid.Row="7" Text="{l:Localize Valuation}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="7" Style="{DynamicResource ValueLabel}">
-									<Label.FormattedText>
-										<FormattedString>
-											<Span Text="{Binding Value}"/>
-											<Span Text=" "/>
-											<Span Text="{Binding Currency}"/>
-										</FormattedString>
-									</Label.FormattedText>
-								</Label>
+									<Label Grid.Column="0" Grid.Row="8" Text="{l:Localize Created}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="8" Text="{Binding Created, Converter={converters:DateTimeToString}}" Style="{DynamicResource ValueLabel}"/>
 
-								<Label Grid.Column="0" Grid.Row="8" Text="{l:Localize Created}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="8" Text="{Binding Created, Converter={converters:DateTimeToString}}" Style="{DynamicResource ValueLabel}"/>
+									<Label Grid.Column="0" Grid.Row="9" Text="{l:Localize Updated}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="9" Text="{Binding Updated, Converter={converters:DateTimeToString}}" Style="{DynamicResource ValueLabel}"/>
 
-								<Label Grid.Column="0" Grid.Row="9" Text="{l:Localize Updated}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="9" Text="{Binding Updated, Converter={converters:DateTimeToString}}" Style="{DynamicResource ValueLabel}"/>
+									<Label Grid.Column="0" Grid.Row="10" Text="{l:Localize Expires}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="10" Text="{Binding Expires, Converter={converters:DateTimeToString}}" Style="{DynamicResource ValueLabel}"/>
+								</Grid>
 
-								<Label Grid.Column="0" Grid.Row="10" Text="{l:Localize Expires}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="10" Text="{Binding Expires, Converter={converters:DateTimeToString}}" Style="{DynamicResource ValueLabel}"/>
-							</Grid>
+								<Image Source="{Binding Path=GlyphImage}" IsVisible="{Binding Path=HasGlyphImage}"
+						   WidthRequest="{Binding Path=GlyphWidth, Mode=OneTime}" HeightRequest="{Binding Path=GlyphHeight, Mode=OneTime}" 
+						   VerticalOptions="Start" HorizontalOptions="Center" Margin="{DynamicResource SmallTopMargins}" />
 
-							<Image Source="{Binding Path=GlyphImage}" IsVisible="{Binding Path=HasGlyphImage}"
-                       WidthRequest="{Binding Path=GlyphWidth, Mode=OneTime}" HeightRequest="{Binding Path=GlyphHeight, Mode=OneTime}" 
-                       VerticalOptions="Start" HorizontalOptions="Center" Margin="{DynamicResource SmallTopMargins}" />
+								<Image Source="{Binding Path=QrCode}" IsVisible="{Binding Path=HasQrCode}" 
+						   WidthRequest="{Binding Path=QrCodeWidth, Mode=OneTime}" HeightRequest="{Binding Path=QrCodeHeight, Mode=OneTime}" 
+						   VerticalOptions="Start" HorizontalOptions="Center" Margin="{DynamicResource SmallTopMargins}" />
 
-							<Image Source="{Binding Path=QrCode}" IsVisible="{Binding Path=HasQrCode}" 
-                       WidthRequest="{Binding Path=QrCodeWidth, Mode=OneTime}" HeightRequest="{Binding Path=QrCodeHeight, Mode=OneTime}" 
-                       VerticalOptions="Start" HorizontalOptions="Center" Margin="{DynamicResource SmallTopMargins}" />
+								<VerticalStackLayout>
+									<Label Text="{l:Localize Reports}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"
+											 IsVisible="{Binding HasStateMachine}"/>
 
-							<VerticalStackLayout>
-								<Label Text="{l:Localize Reports}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"
-										 IsVisible="{Binding HasStateMachine}"/>
+									<controls:TextButton LabelData="{l:Localize Present}" Margin="{DynamicResource SmallBottomMargins}"
+																Command="{Binding Path=PresentReportCommand}" IsVisible="{Binding HasStateMachine}"
+																IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+																Style="{DynamicResource FilledTextButton}"/>
 
-								<controls:TextButton LabelData="{l:Localize Present}" Margin="{DynamicResource SmallBottomMargins}"
-															Command="{Binding Path=PresentReportCommand}" IsVisible="{Binding HasStateMachine}"
+									<controls:TextButton LabelData="{l:Localize History}" Margin="{DynamicResource SmallBottomMargins}"
+																Command="{Binding Path=HistoryReportCommand}"
+																IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+																IsVisible="{Binding HasStateMachine}" Style="{DynamicResource FilledTextButton}"/>
+
+									<controls:TextButton LabelData="{l:Localize Variables}" Margin="{DynamicResource SmallBottomMargins}"
+																Command="{Binding Path=VariablesReportCommand}" Style="{DynamicResource FilledTextButton}"
+																IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+																IsVisible="{Binding HasStateMachine}"/>
+
+									<controls:TextButton LabelData="{l:Localize States}" Margin="{DynamicResource SmallBottomMargins}"
+																Command="{Binding Path=StatesReportCommand}" Style="{DynamicResource FilledTextButton}"
+																IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+																IsVisible="{Binding HasStateMachine}"/>
+
+									<controls:TextButton LabelData="{l:Localize Profiling}" Margin="{DynamicResource SmallBottomMargins}"
+																Command="{Binding Path=ProfilingReportCommand}" Style="{DynamicResource FilledTextButton}"
+																IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+																IsVisible="{Binding HasStateMachine}"/>
+								</VerticalStackLayout>
+
+								<Label Text="{l:Localize Parts}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"/>
+								<Label Text="{l:Localize TokenPartsInfoText}" Style="{DynamicResource InfoLabel}" VerticalOptions="Start"/>
+
+								<Grid x:Name="PartsGrid">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="*"/>
+										<ColumnDefinition Width="*"/>
+									</Grid.ColumnDefinitions>
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+									</Grid.RowDefinitions>
+
+									<Label Grid.Column="0" Grid.Row="0" Text="{l:Localize Owner}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="0" Text="{Binding OwnerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
+										</Label.GestureRecognizers>
+									</Label>
+
+									<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize OwnerJid}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="1" Text="{Binding OwnerJid}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding OpenChatCommand}" CommandParameter="Owner" />
+										</Label.GestureRecognizers>
+									</Label>
+
+									<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize OwnershipContract}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnershipContract}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding OwnershipContract}" />
+										</Label.GestureRecognizers>
+									</Label>
+
+									<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize Creator}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="3" Text="{Binding CreatorFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Creator}" />
+										</Label.GestureRecognizers>
+									</Label>
+
+									<Label Grid.Column="0" Grid.Row="4" Text="{l:Localize CreatorJid}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="4" Text="{Binding CreatorJid}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding OpenChatCommand}" CommandParameter="Creator" />
+										</Label.GestureRecognizers>
+									</Label>
+
+									<Label Grid.Column="0" Grid.Row="5" Text="{l:Localize CreationContract}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="5" Text="{Binding CreationContract}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding CreationContract}" />
+										</Label.GestureRecognizers>
+									</Label>
+
+									<Label Grid.Column="0" Grid.Row="6" Text="{l:Localize TrustProvider}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="6" Text="{Binding TrustProviderFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding TrustProvider}" />
+										</Label.GestureRecognizers>
+									</Label>
+
+									<Label Grid.Column="0" Grid.Row="7" Text="{l:Localize TrustProviderJid}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="7" Text="{Binding TrustProviderJid}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding OpenChatCommand}" CommandParameter="TrustProvider" />
+										</Label.GestureRecognizers>
+									</Label>
+								</Grid>
+
+								<Label Text="{l:Localize Privileges}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"/>
+								<Label Text="{l:Localize TokenPrivilegesInfoText}" Style="{DynamicResource InfoLabel}" VerticalOptions="Start"/>
+
+								<Grid>
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="4*"/>
+										<ColumnDefinition Width="*"/>
+									</Grid.ColumnDefinitions>
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+									</Grid.RowDefinitions>
+
+									<Label Grid.Column="0" Grid.Row="0" Text="{l:Localize CreatorCanDestroy}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="0" Text="{Binding CreatorCanDestroy, Converter={converters:BooleanToYesNo}}" Style="{DynamicResource ValueLabel}" HorizontalOptions="Center"/>
+
+									<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize OwnerCanDestroyBatch}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="1" Text="{Binding OwnerCanDestroyBatch, Converter={converters:BooleanToYesNo}}" Style="{DynamicResource ValueLabel}" HorizontalOptions="Center"/>
+
+									<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize OwnerCanDestroyIndividual}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnerCanDestroyIndividual, Converter={converters:BooleanToYesNo}}" Style="{DynamicResource ValueLabel}" HorizontalOptions="Center"/>
+
+									<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize CertifierCanDestroy}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="3" Text="{Binding CertifierCanDestroy, Converter={converters:BooleanToYesNo}}" Style="{DynamicResource ValueLabel}" HorizontalOptions="Center"/>
+								</Grid>
+
+								<Label Text="{l:Localize MachineReadableText}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"/>
+								<Label Text="{l:Localize MachineReadableInfoTextToken}" Style="{DynamicResource InfoLabel}" VerticalOptions="Start"/>
+
+								<Grid Margin="{DynamicResource SmallBottomMargins}">
+									<Grid.ColumnDefinitions>
+										<ColumnDefinition Width="*"/>
+										<ColumnDefinition Width="*"/>
+									</Grid.ColumnDefinitions>
+									<Grid.RowDefinitions>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+										<RowDefinition Height="Auto"/>
+									</Grid.RowDefinitions>
+
+									<Label Grid.Column="0" Grid.Row="0" Text="{l:Localize Signature}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="0" Text="{Binding Signature, Converter={converters:BinaryToBase64}}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Signature, Converter={converters:BinaryToBase64}}" />
+										</Label.GestureRecognizers>
+									</Label>
+
+									<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Timestamp}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="1" Text="{Binding SignatureTimestamp, Converter={converters:DateTimeToString}}" Style="{DynamicResource ValueLabel}"/>
+
+									<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize DefinitionNamespace}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="2" Text="{Binding DefinitionNamespace}" Style="{DynamicResource ClickableValueLabel}" HorizontalOptions="Center">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding OpenLinkCommand}" CommandParameter="{Binding DefinitionNamespace}" />
+										</Label.GestureRecognizers>
+									</Label>
+
+									<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize DefinitionSchemaDigest}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="3" Text="{Binding DefinitionSchemaDigest, Converter={converters:BinaryToBase64}}" Style="{DynamicResource ClickableValueLabel}">
+										<Label.GestureRecognizers>
+											<TapGestureRecognizer Command="{Binding OpenLinkCommand}" CommandParameter="{Binding DefinitionSchemaUrl}" />
+										</Label.GestureRecognizers>
+									</Label>
+
+									<Label Grid.Column="0" Grid.Row="4" Text="{l:Localize HashFunction}" Style="{DynamicResource KeyLabel}"/>
+									<Label Grid.Column="1" Grid.Row="4" Text="{Binding DefinitionSchemaHashFunction}" Style="{DynamicResource ValueLabel}"/>
+								</Grid>
+
+								<controls:TextButton LabelData="{l:Localize ShowM2MInfo}" Margin="{DynamicResource SmallBottomMargins}"
+															Command="{Binding Path=ShowM2mInfoCommand}" Style="{DynamicResource FilledTextButton}"
+															IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}" />
+
+								<Label Text="{l:Localize Actions}" Margin="{DynamicResource SmallTopMargins}"
+										 VerticalOptions="Start"/>
+
+								<controls:TextButton LabelData="{l:Localize SendToContact}" Margin="{DynamicResource SmallBottomMargins}"
+															Command="{Binding Path=SendToContactCommand}" Style="{DynamicResource FilledTextButton}"
+															IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}" />
+
+								<controls:TextButton LabelData="{l:Localize Share}" Margin="{DynamicResource SmallBottomMargins}"
+															Command="{Binding Path=ShareCommand}" Style="{DynamicResource FilledTextButton}"
+															IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}" />
+
+								<controls:TextButton LabelData="{l:Localize PublishMarketplace}" Margin="{DynamicResource SmallBottomMargins}"
+													Command="{Binding Path=PublishMarketplaceCommand}" Style="{DynamicResource FilledTextButton}"
+													IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+													IsVisible="{Binding IsMyToken}"/>
+
+								<controls:TextButton LabelData="{l:Localize OfferToSell}" Margin="{DynamicResource SmallBottomMargins}"
+															Command="{Binding Path=OfferToSellCommand}" Style="{DynamicResource FilledTextButton}"
 															IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-															Style="{DynamicResource FilledTextButton}"/>
+															IsVisible="{Binding IsMyToken}"/>
 
-								<controls:TextButton LabelData="{l:Localize History}" Margin="{DynamicResource SmallBottomMargins}"
-															Command="{Binding Path=HistoryReportCommand}"
+								<controls:TextButton LabelData="{l:Localize OfferToBuy}" Margin="{DynamicResource SmallBottomMargins}"
+															Command="{Binding Path=OfferToBuyCommand}" Style="{DynamicResource FilledTextButton}"
 															IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-															IsVisible="{Binding HasStateMachine}" Style="{DynamicResource FilledTextButton}"/>
+															IsVisible="{Binding IsMyToken, Converter={StaticResource InvertedBoolConverter}}"/>
 
-								<controls:TextButton LabelData="{l:Localize Variables}" Margin="{DynamicResource SmallBottomMargins}"
-															Command="{Binding Path=VariablesReportCommand}" Style="{DynamicResource FilledTextButton}"
-															IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-															IsVisible="{Binding HasStateMachine}"/>
-
-								<controls:TextButton LabelData="{l:Localize States}" Margin="{DynamicResource SmallBottomMargins}"
-															Command="{Binding Path=StatesReportCommand}" Style="{DynamicResource FilledTextButton}"
-															IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-															IsVisible="{Binding HasStateMachine}"/>
-
-								<controls:TextButton LabelData="{l:Localize Profiling}" Margin="{DynamicResource SmallBottomMargins}"
-															Command="{Binding Path=ProfilingReportCommand}" Style="{DynamicResource FilledTextButton}"
-															IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-															IsVisible="{Binding HasStateMachine}"/>
+								<controls:TextButton LabelData="{l:Localize ViewEvents}" Margin="{DynamicResource SmallBottomMargins}"
+															Command="{Binding Path=ViewEventsCommand}" Style="{DynamicResource FilledTextButton}"
+															IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"/>
 							</VerticalStackLayout>
-
-							<Label Text="{l:Localize Parts}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"/>
-							<Label Text="{l:Localize TokenPartsInfoText}" Style="{DynamicResource InfoLabel}" VerticalOptions="Start"/>
-
-							<Grid x:Name="PartsGrid">
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*"/>
-									<ColumnDefinition Width="*"/>
-								</Grid.ColumnDefinitions>
-								<Grid.RowDefinitions>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-								</Grid.RowDefinitions>
-
-								<Label Grid.Column="0" Grid.Row="0" Text="{l:Localize Owner}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="0" Text="{Binding OwnerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
-									</Label.GestureRecognizers>
-								</Label>
-
-								<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize OwnerJid}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="1" Text="{Binding OwnerJid}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding OpenChatCommand}" CommandParameter="Owner" />
-									</Label.GestureRecognizers>
-								</Label>
-
-								<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize OwnershipContract}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnershipContract}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding OwnershipContract}" />
-									</Label.GestureRecognizers>
-								</Label>
-
-								<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize Creator}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="3" Text="{Binding CreatorFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Creator}" />
-									</Label.GestureRecognizers>
-								</Label>
-
-								<Label Grid.Column="0" Grid.Row="4" Text="{l:Localize CreatorJid}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="4" Text="{Binding CreatorJid}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding OpenChatCommand}" CommandParameter="Creator" />
-									</Label.GestureRecognizers>
-								</Label>
-
-								<Label Grid.Column="0" Grid.Row="5" Text="{l:Localize CreationContract}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="5" Text="{Binding CreationContract}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding CreationContract}" />
-									</Label.GestureRecognizers>
-								</Label>
-
-								<Label Grid.Column="0" Grid.Row="6" Text="{l:Localize TrustProvider}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="6" Text="{Binding TrustProviderFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding TrustProvider}" />
-									</Label.GestureRecognizers>
-								</Label>
-
-								<Label Grid.Column="0" Grid.Row="7" Text="{l:Localize TrustProviderJid}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="7" Text="{Binding TrustProviderJid}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding OpenChatCommand}" CommandParameter="TrustProvider" />
-									</Label.GestureRecognizers>
-								</Label>
-							</Grid>
-
-							<Label Text="{l:Localize Privileges}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"/>
-							<Label Text="{l:Localize TokenPrivilegesInfoText}" Style="{DynamicResource InfoLabel}" VerticalOptions="Start"/>
-
-							<Grid>
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="4*"/>
-									<ColumnDefinition Width="*"/>
-								</Grid.ColumnDefinitions>
-								<Grid.RowDefinitions>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-								</Grid.RowDefinitions>
-
-								<Label Grid.Column="0" Grid.Row="0" Text="{l:Localize CreatorCanDestroy}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="0" Text="{Binding CreatorCanDestroy, Converter={converters:BooleanToYesNo}}" Style="{DynamicResource ValueLabel}" HorizontalOptions="Center"/>
-
-								<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize OwnerCanDestroyBatch}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="1" Text="{Binding OwnerCanDestroyBatch, Converter={converters:BooleanToYesNo}}" Style="{DynamicResource ValueLabel}" HorizontalOptions="Center"/>
-
-								<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize OwnerCanDestroyIndividual}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnerCanDestroyIndividual, Converter={converters:BooleanToYesNo}}" Style="{DynamicResource ValueLabel}" HorizontalOptions="Center"/>
-
-								<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize CertifierCanDestroy}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="3" Text="{Binding CertifierCanDestroy, Converter={converters:BooleanToYesNo}}" Style="{DynamicResource ValueLabel}" HorizontalOptions="Center"/>
-							</Grid>
-
-							<Label Text="{l:Localize MachineReadableText}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"/>
-							<Label Text="{l:Localize MachineReadableInfoTextToken}" Style="{DynamicResource InfoLabel}" VerticalOptions="Start"/>
-
-							<Grid Margin="{DynamicResource SmallBottomMargins}">
-								<Grid.ColumnDefinitions>
-									<ColumnDefinition Width="*"/>
-									<ColumnDefinition Width="*"/>
-								</Grid.ColumnDefinitions>
-								<Grid.RowDefinitions>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-									<RowDefinition Height="Auto"/>
-								</Grid.RowDefinitions>
-
-								<Label Grid.Column="0" Grid.Row="0" Text="{l:Localize Signature}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="0" Text="{Binding Signature, Converter={converters:BinaryToBase64}}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Signature, Converter={converters:BinaryToBase64}}" />
-									</Label.GestureRecognizers>
-								</Label>
-
-								<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Timestamp}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="1" Text="{Binding SignatureTimestamp, Converter={converters:DateTimeToString}}" Style="{DynamicResource ValueLabel}"/>
-
-								<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize DefinitionNamespace}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="2" Text="{Binding DefinitionNamespace}" Style="{DynamicResource ClickableValueLabel}" HorizontalOptions="Center">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding OpenLinkCommand}" CommandParameter="{Binding DefinitionNamespace}" />
-									</Label.GestureRecognizers>
-								</Label>
-
-								<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize DefinitionSchemaDigest}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="3" Text="{Binding DefinitionSchemaDigest, Converter={converters:BinaryToBase64}}" Style="{DynamicResource ClickableValueLabel}">
-									<Label.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding OpenLinkCommand}" CommandParameter="{Binding DefinitionSchemaUrl}" />
-									</Label.GestureRecognizers>
-								</Label>
-
-								<Label Grid.Column="0" Grid.Row="4" Text="{l:Localize HashFunction}" Style="{DynamicResource KeyLabel}"/>
-								<Label Grid.Column="1" Grid.Row="4" Text="{Binding DefinitionSchemaHashFunction}" Style="{DynamicResource ValueLabel}"/>
-							</Grid>
-
-							<controls:TextButton LabelData="{l:Localize ShowM2MInfo}" Margin="{DynamicResource SmallBottomMargins}"
-														Command="{Binding Path=ShowM2mInfoCommand}" Style="{DynamicResource FilledTextButton}"
-														IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}" />
-
-							<Label Text="{l:Localize Actions}" Margin="{DynamicResource SmallTopMargins}"
-									 VerticalOptions="Start"/>
-
-							<controls:TextButton LabelData="{l:Localize SendToContact}" Margin="{DynamicResource SmallBottomMargins}"
-														Command="{Binding Path=SendToContactCommand}" Style="{DynamicResource FilledTextButton}"
-														IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}" />
-
-							<controls:TextButton LabelData="{l:Localize Share}" Margin="{DynamicResource SmallBottomMargins}"
-														Command="{Binding Path=ShareCommand}" Style="{DynamicResource FilledTextButton}"
-														IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}" />
-
-							<controls:TextButton LabelData="{l:Localize PublishMarketplace}" Margin="{DynamicResource SmallBottomMargins}"
-												Command="{Binding Path=PublishMarketplaceCommand}" Style="{DynamicResource FilledTextButton}"
-												IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-												IsVisible="{Binding IsMyToken}"/>
-
-							<controls:TextButton LabelData="{l:Localize OfferToSell}" Margin="{DynamicResource SmallBottomMargins}"
-														Command="{Binding Path=OfferToSellCommand}" Style="{DynamicResource FilledTextButton}"
-														IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-														IsVisible="{Binding IsMyToken}"/>
-
-							<controls:TextButton LabelData="{l:Localize OfferToBuy}" Margin="{DynamicResource SmallBottomMargins}"
-														Command="{Binding Path=OfferToBuyCommand}" Style="{DynamicResource FilledTextButton}"
-														IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
-														IsVisible="{Binding IsMyToken, Converter={StaticResource InvertedBoolConverter}}"/>
-
-							<controls:TextButton LabelData="{l:Localize ViewEvents}" Margin="{DynamicResource SmallBottomMargins}"
-														Command="{Binding Path=ViewEventsCommand}" Style="{DynamicResource FilledTextButton}"
-														IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"/>
 						</VerticalStackLayout>
-					</VerticalStackLayout>
-				</Border>
-			</VerticalStackLayout>
-		</ScrollView>
+					</Border>
+				</VerticalStackLayout>
+			</ScrollView>
+		</Grid>
 	</Grid>
 </base:BaseContentPage>

--- a/NeuroAccessMaui/UI/Rendering/MauiRenderer.cs
+++ b/NeuroAccessMaui/UI/Rendering/MauiRenderer.cs
@@ -26,6 +26,7 @@ using MarkdownContent = Waher.Content.Markdown.MarkdownContent;
 using Svg;
 using Microsoft.Maui.Controls.Shapes;
 using Waher.Script.Functions.Strings;
+using System.Runtime.Intrinsics.Arm;
 
 namespace NeuroAccessMaui.UI.Rendering
 {
@@ -1528,9 +1529,23 @@ namespace NeuroAccessMaui.UI.Rendering
 			{
 				try
 				{
-					// TODO ?
-					if (await Renderer.RenderMauiXaml(Rend, Element.Rows, Element.Language, Element.Indent, Element.Document))
+					if (Element.Language.Equals("image/png", StringComparison.OrdinalIgnoreCase))
+					{
+						string Bin = Element.Rows[0];
+						byte[] Data = Convert.FromBase64String(Bin);
+						string Uri = "data:image/png;base64," + Convert.ToBase64String(Data, 0, Data.Length);
+
+						await this.OutputMaui(new Waher.Content.Emoji.ImageSource()
+						{
+							Url = Uri
+						});
+
 						return;
+					}
+
+					// TODO ?
+					//if (await Renderer.RenderMauiXaml(Rend, Element.Rows, Element.Language, Element.Indent, Element.Document))
+					//	return;
 				}
 				catch (Exception Ex)
 				{
@@ -2215,9 +2230,6 @@ namespace NeuroAccessMaui.UI.Rendering
 				Vsl.Add(Label);
 			}
 
-			if (Source.Width.HasValue)
-				Sv.WidthRequest = Source.Width.Value;
-
 			if (Source.Height.HasValue)
 				Sv.HeightRequest = Source.Height.Value;
 
@@ -2273,6 +2285,7 @@ namespace NeuroAccessMaui.UI.Rendering
 				int? Width = Source.Width;
 				int? Height = Source.Height;
 				byte[] Data = Convert.FromBase64String(Url.Substring(i + 7));
+
 				using (SKBitmap Bitmap = SKBitmap.Decode(Data))
 				{
 					Width = Bitmap.Width;


### PR DESCRIPTION
<!--
Thank you for your contribution! Please fill out the sections below.
-->

# Fix Token report rendering

## 📋 Description

This PR contains fixes and changes to make the token MachineReport use the new MAUI renderer from markdown to a vertical stack layout instead of markdown to xaml. Also updates some related page margins and placements and adds an activity indicator while image is rendering.

Currently only checks for PNGs. Rendering only affects Tokens with state machines

**What kind of change does this PR introduce?**

* [x] Bug fix
* [x] New feature
* [ ] Documentation update
* [x] Refactoring
* [x] Performance improvement
* [ ] Other (please describe): \_\_\_\_\_\_\_\_\_\_

## 🔄 Changelog

<!-- Please add one-line entries in the appropriate categories. If none apply, remove the category. -->

### Added

* Added rendering of Token reports

### Changed

* Updated layout on Token page