### PR TITLE
Viewing token embedded layouts and statemachine killed event

### DIFF
--- a/NeuroAccessMaui/App.xaml.cs
+++ b/NeuroAccessMaui/App.xaml.cs
@@ -52,10 +52,12 @@ using NeuroAccessMaui.UI.Pages.Things.MyThings;
 using NeuroAccessMaui.UI.Pages.Things.ReadSensor;
 using NeuroAccessMaui.UI.Pages.Things.ViewClaimThing;
 using NeuroAccessMaui.UI.Pages.Things.ViewThing;
+using NeuroAccessMaui.UI.Pages.Utility;
 using NeuroAccessMaui.UI.Pages.Utility.Images;
 using NeuroAccessMaui.UI.Pages.Wallet.AccountEvent;
 using NeuroAccessMaui.UI.Pages.Wallet.BuyEDaler;
 using NeuroAccessMaui.UI.Pages.Wallet.EDalerReceived;
+using NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout;
 using NeuroAccessMaui.UI.Pages.Wallet.IssueEDaler;
 using NeuroAccessMaui.UI.Pages.Wallet.MachineReport;
 using NeuroAccessMaui.UI.Pages.Wallet.MachineVariables;
@@ -109,6 +111,7 @@ using Waher.Security.JWS;
 using Waher.Security.JWT;
 using Waher.Security.LoginMonitor;
 using Waher.Things;
+using Waher.Layout;
 
 namespace NeuroAccessMaui
 {
@@ -534,7 +537,8 @@ namespace NeuroAccessMaui
                         typeof(GraphEncoder).Assembly,
                         typeof(XmppServerlessMessaging).Assembly,
                         typeof(HttpxClient).Assembly,
-						typeof(Waher.Script.Persistence.SQL.Select).Assembly);
+						typeof(Waher.Script.Persistence.SQL.Select).Assembly,
+						typeof(Waher.Layout.Layout2D.Layout2DDocument).Assembly);
                 }
 
                 // Register exceptions as alerts.
@@ -671,6 +675,7 @@ namespace NeuroAccessMaui
 			Routing.RegisterRoute(nameof(TokenEventsPage), typeof(TokenEventsPage));
 			Routing.RegisterRoute(nameof(WalletPage), typeof(WalletPage));
 			Routing.RegisterRoute(nameof(TransactionHistoryPage), typeof(TransactionHistoryPage));
+			Routing.RegisterRoute(nameof(EmbeddedLayoutPage), typeof(EmbeddedLayoutPage));
 
 			// Utility
 			Routing.RegisterRoute(nameof(ImageCroppingPage), typeof(ImageCroppingPage));

--- a/NeuroAccessMaui/Resources/Languages/AppResources.Designer.cs
+++ b/NeuroAccessMaui/Resources/Languages/AppResources.Designer.cs
@@ -4012,6 +4012,33 @@ namespace NeuroAccessMaui.Resources.Languages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Killed.
+        /// </summary>
+        public static string Killed {
+            get {
+                return ResourceManager.GetString("Killed", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Killer id.
+        /// </summary>
+        public static string KillerId {
+            get {
+                return ResourceManager.GetString("KillerId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Killer user.
+        /// </summary>
+        public static string KillerUser {
+            get {
+                return ResourceManager.GetString("KillerUser", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Apply.
         /// </summary>
         public static string Kyc_Apply {

--- a/NeuroAccessMaui/Resources/Languages/AppResources.Designer.cs
+++ b/NeuroAccessMaui/Resources/Languages/AppResources.Designer.cs
@@ -2896,6 +2896,15 @@ namespace NeuroAccessMaui.Resources.Languages {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Embedded layout.
+        /// </summary>
+        public static string EmbeddedLayout {
+            get {
+                return ResourceManager.GetString("EmbeddedLayout", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Enable.
         /// </summary>
         public static string Enable {
@@ -10029,6 +10038,15 @@ namespace NeuroAccessMaui.Resources.Languages {
         public static string ViewContract {
             get {
                 return ResourceManager.GetString("ViewContract", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to View embedded layout.
+        /// </summary>
+        public static string ViewEmbeddedLayout {
+            get {
+                return ResourceManager.GetString("ViewEmbeddedLayout", resourceCulture);
             }
         }
         

--- a/NeuroAccessMaui/Resources/Languages/AppResources.resx
+++ b/NeuroAccessMaui/Resources/Languages/AppResources.resx
@@ -3591,4 +3591,13 @@
   <data name="ViewEmbeddedLayout">
     <value>View embedded layout</value>
   </data>
+  <data name="Killed">
+    <value>Killed</value>
+  </data>
+  <data name="KillerUser">
+    <value>Killer user</value>
+  </data>
+  <data name="KillerId">
+    <value>Killer id</value>
+  </data>
 </root>

--- a/NeuroAccessMaui/Resources/Languages/AppResources.resx
+++ b/NeuroAccessMaui/Resources/Languages/AppResources.resx
@@ -3585,4 +3585,10 @@
   <data name="ShowAccount" xml:space="preserve">
     <value>Show account</value>
   </data>
+  <data name="EmbeddedLayout">
+    <value>Embedded layout</value>
+  </data>
+  <data name="ViewEmbeddedLayout">
+    <value>View embedded layout</value>
+  </data>
 </root>

--- a/NeuroAccessMaui/UI/PageAppExtension.cs
+++ b/NeuroAccessMaui/UI/PageAppExtension.cs
@@ -90,6 +90,8 @@ using NeuroAccessMaui.UI.Popups.Xmpp.SubscriptionRequest;
 using Waher.Runtime.Inventory;
 using NeuroAccessMaui.UI.Pages.Wallet.TransactionHistory;
 using NeuroAccessMaui.UI.Popups.OnboardingHelp;
+using NeuroAccessMaui.UI.Pages.Utility;
+using NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout;
 
 namespace NeuroAccessMaui.UI
 {
@@ -264,6 +266,7 @@ namespace NeuroAccessMaui.UI
 			Builder.Services.AddTransient<TokenEventsPage, TokenEventsViewModel>();
 			Builder.Services.AddTransient<WalletPage, WalletViewModel>();
 			Builder.Services.AddTransient<TransactionHistoryPage, TransactionHistoryViewModel>();
+			Builder.Services.AddTransient<EmbeddedLayoutPage, EmbeddedLayoutViewModel>();
 
 			// Popups
 			Builder.Services.AddTransient<ImageView>();

--- a/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutNavigationArgs.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutNavigationArgs.cs
@@ -1,0 +1,20 @@
+﻿using NeuroAccessMaui.Services.UI;
+using NeuroAccessMaui.UI.Pages.Wallet.MyWallet.ObjectModels;
+
+namespace NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout
+{
+	public class EmbeddedLayoutNavigationArgs : NavigationArgs
+	{
+		public EmbeddedLayoutNavigationArgs()
+		{
+
+		}
+
+		public EmbeddedLayoutNavigationArgs(TokenItem TokenItem)
+		{
+			this.TokenItem = TokenItem;
+		}
+
+		public TokenItem TokenItem { get; }
+	}
+}

--- a/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutNavigationArgs.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutNavigationArgs.cs
@@ -3,18 +3,31 @@ using NeuroAccessMaui.UI.Pages.Wallet.MyWallet.ObjectModels;
 
 namespace NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout
 {
+	/// <summary>
+	/// Navigation arguments used when navigating to the embedded layout page.
+	/// </summary>
 	public class EmbeddedLayoutNavigationArgs : NavigationArgs
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="EmbeddedLayoutNavigationArgs"/> class.
+		/// </summary>
 		public EmbeddedLayoutNavigationArgs()
 		{
 
 		}
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="EmbeddedLayoutNavigationArgs"/> class.
+		/// </summary>
+		/// <param name="TokenItem">Token item containing the embedded layout to render.</param>
 		public EmbeddedLayoutNavigationArgs(TokenItem TokenItem)
 		{
 			this.TokenItem = TokenItem;
 		}
 
-		public TokenItem TokenItem { get; }
+		/// <summary>
+		/// Gets the token item containing the embedded layout to render.
+		/// </summary>
+		public TokenItem? TokenItem { get; }
 	}
 }

--- a/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutPage.xaml
+++ b/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutPage.xaml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<base:BaseContentPage x:Name="ThisPage"
+							 x:Class="NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout.EmbeddedLayoutPage"
+							 x:DataType="viewmodel:EmbeddedLayoutViewModel"
+							 xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+							 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+							 xmlns:l="clr-namespace:NeuroAccessMaui.Services.Localization"
+							 xmlns:mct="http://schemas.microsoft.com/dotnet/2022/maui/toolkit"
+							 xmlns:ui="clr-namespace:NeuroAccessMaui.UI"
+							 xmlns:base="clr-namespace:NeuroAccessMaui.UI.Pages"
+							 xmlns:controls="clr-namespace:NeuroAccessMaui.UI.Controls"
+							 xmlns:converters="clr-namespace:NeuroAccessMaui.UI.Converters"
+							 xmlns:viewmodel="clr-namespace:NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout">
+	<Grid BackgroundColor="{DynamicResource SurfaceBackgroundWL}" RowDefinitions="auto, *">
+		<controls:Background Grid.RowSpan="2"/>
+
+		<Grid ColumnDefinitions="auto, *"  Margin="16,8,16,8" ColumnSpacing="16">
+			<controls:SvgButton HorizontalOptions="Start" VerticalOptions="Center" Command="{Binding GoBackCommand}"
+								Style="{DynamicResource IconButton}" SvgSource="close.svg" />
+		</Grid>
+
+		<controls:ConditionView Grid.Row="1" Condition="{Binding Loaded}">
+			<controls:ConditionView.False>
+				<ActivityIndicator IsRunning="True" Color="{DynamicResource PrimaryWL}" HorizontalOptions="Center" VerticalOptions="Center"/>
+			</controls:ConditionView.False>
+			<controls:ConditionView.True>
+				<ScrollView>
+					<VerticalStackLayout Spacing="{DynamicResource SmallSpacing}">
+						<Border Style="{DynamicResource BorderSet}">
+							<VerticalStackLayout Spacing="{DynamicResource LargeSpacing}">
+								<Image Grid.Row="1" Source="{Binding RenderedLayout}" />
+							</VerticalStackLayout>
+						</Border>
+					</VerticalStackLayout>
+				</ScrollView>
+			</controls:ConditionView.True>
+		</controls:ConditionView>
+	</Grid>
+
+</base:BaseContentPage>

--- a/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutPage.xaml.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutPage.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using NeuroAccessMaui.Services;
+using NeuroAccessMaui.UI.Pages.Wallet.MachineReport;
+
+namespace NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout
+{
+	public partial class EmbeddedLayoutPage
+	{
+		public EmbeddedLayoutPage()
+		{
+			this.InitializeComponent();
+			this.ContentPageModel = new EmbeddedLayoutViewModel(ServiceRef.NavigationService.PopLatestArgs<EmbeddedLayoutNavigationArgs>());
+		}
+	}
+}

--- a/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutPage.xaml.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutPage.xaml.cs
@@ -6,8 +6,14 @@ using NeuroAccessMaui.UI.Pages.Wallet.MachineReport;
 
 namespace NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout
 {
+	/// <summary>
+	/// Page used to display a token's embedded layout.
+	/// </summary>
 	public partial class EmbeddedLayoutPage
 	{
+		/// <summary>
+		/// Initializes a new instance of the <see cref="EmbeddedLayoutPage"/> class.
+		/// </summary>
 		public EmbeddedLayoutPage()
 		{
 			this.InitializeComponent();

--- a/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutViewModel.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using NeuroAccessMaui.UI.Pages.Wallet.TokenDetails;
+using Waher.Script.Functions.ComplexNumbers;
+
+namespace NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout
+{
+	public partial class EmbeddedLayoutViewModel : BaseViewModel
+	{
+		private readonly EmbeddedLayoutNavigationArgs? navigationArguments;
+
+		[ObservableProperty]
+		private ImageSource? renderedLayout;
+
+		[ObservableProperty]
+		private bool loaded = false;
+
+		public EmbeddedLayoutViewModel(EmbeddedLayoutNavigationArgs? Args)
+		{
+			this.navigationArguments = Args;
+		}
+
+		public override async Task OnInitializeAsync()
+		{
+			await base.OnInitializeAsync();
+
+			if (!(navigationArguments is null))
+			{
+				await MainThread.InvokeOnMainThreadAsync(async () =>
+				{
+					this.RenderedLayout = await navigationArguments.TokenItem.RenderEmbeddedLayout();
+					this.Loaded = true;
+				});
+			}
+		}
+	}
+}

--- a/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/EmbeddedLayout/EmbeddedLayoutViewModel.cs
@@ -8,6 +8,9 @@ using Waher.Script.Functions.ComplexNumbers;
 
 namespace NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout
 {
+	/// <summary>
+	/// View model for displaying a rendered embedded layout associated with a token.
+	/// </summary>
 	public partial class EmbeddedLayoutViewModel : BaseViewModel
 	{
 		private readonly EmbeddedLayoutNavigationArgs? navigationArguments;
@@ -18,23 +21,34 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.EmbeddedLayout
 		[ObservableProperty]
 		private bool loaded = false;
 
+		/// <summary>
+		/// Initializes a new instance of the <see cref="EmbeddedLayoutViewModel"/> class.
+		/// </summary>
+		/// <param name="Args">Navigation arguments, if any.</param>
 		public EmbeddedLayoutViewModel(EmbeddedLayoutNavigationArgs? Args)
 		{
 			this.navigationArguments = Args;
 		}
 
+		/// <summary>
+		/// Initializes the view model asynchronously.
+		/// </summary>
+		/// <returns>A task representing the asynchronous operation.</returns>
 		public override async Task OnInitializeAsync()
 		{
 			await base.OnInitializeAsync();
 
-			if (!(navigationArguments is null))
+			await MainThread.InvokeOnMainThreadAsync(async () =>
 			{
-				await MainThread.InvokeOnMainThreadAsync(async () =>
-				{
-					this.RenderedLayout = await navigationArguments.TokenItem.RenderEmbeddedLayout();
-					this.Loaded = true;
-				});
-			}
+				if (this.navigationArguments is null)
+					return;
+
+				if (this.navigationArguments.TokenItem is null)
+					return;
+
+				this.RenderedLayout = await this.navigationArguments.TokenItem.RenderEmbeddedLayout();
+				this.Loaded = true;
+			});
 		}
 	}
 }

--- a/NeuroAccessMaui/UI/Pages/Wallet/MyWallet/ObjectModels/TokenItem.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MyWallet/ObjectModels/TokenItem.cs
@@ -1,11 +1,14 @@
-﻿using CommunityToolkit.Mvvm.ComponentModel;
+﻿using System.Xml;
+using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using NeuroAccessMaui.Services;
+using NeuroAccessMaui.Services.Kyc.ViewModels;
 using NeuroAccessMaui.Services.Notification;
 using NeuroAccessMaui.Services.UI;
 using NeuroAccessMaui.UI.Pages.Wallet.TokenDetails;
 using NeuroFeatures;
 using NeuroFeatures.Tags;
+using SkiaSharp;
 using Waher.Content;
 using Waher.Networking.XMPP.Contracts;
 using Waher.Security;
@@ -299,6 +302,16 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MyWallet.ObjectModels
 		public bool HasStateMachine => this.token.HasStateMachine;
 
 		/// <summary>
+		/// If the token have an embedded layout.
+		/// </summary>
+		public bool HasEmbeddedLayout => this.token.HasEmbeddedLayout;
+
+		/// <summary>
+		/// The embedded layout of the token.
+		/// </summary>
+		public XmlElement EmbeddedLayoutDefinition => this.token.EmbeddedLayoutDefinition;
+
+		/// <summary>
 		/// Gets or sets the image representing the glyph.
 		/// </summary>
 		[ObservableProperty]
@@ -369,6 +382,21 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MyWallet.ObjectModels
 					Task.Run(() => ServiceRef.NotificationService.DeleteEvents(ToDelete));
 				}
 			}
+		}
+
+		public async Task<ImageSource?> RenderEmbeddedLayout()
+		{
+			if (!this.Token.HasEmbeddedLayout)
+				return null;
+
+			SkiaSharp.SKImage Img = await this.Token?.RenderEmbeddedLayout();
+
+
+			return ImageSource.FromStream(() =>
+			{
+				SKData Data = Img.Encode(SKEncodedImageFormat.Png, 100);
+				return Data.AsStream();
+			});
 		}
 
 		/// <summary>

--- a/NeuroAccessMaui/UI/Pages/Wallet/MyWallet/ObjectModels/TokenItem.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/MyWallet/ObjectModels/TokenItem.cs
@@ -389,8 +389,7 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.MyWallet.ObjectModels
 			if (!this.Token.HasEmbeddedLayout)
 				return null;
 
-			SkiaSharp.SKImage Img = await this.Token?.RenderEmbeddedLayout();
-
+			SkiaSharp.SKImage Img = await this.Token.RenderEmbeddedLayout();
 
 			return ImageSource.FromStream(() =>
 			{

--- a/NeuroAccessMaui/UI/Pages/Wallet/TokenDetails/TokenDetailsPage.xaml
+++ b/NeuroAccessMaui/UI/Pages/Wallet/TokenDetails/TokenDetailsPage.xaml
@@ -119,10 +119,21 @@
 								<Image Source="{Binding Path=QrCode}" IsVisible="{Binding Path=HasQrCode}" 
 						   WidthRequest="{Binding Path=QrCodeWidth, Mode=OneTime}" HeightRequest="{Binding Path=QrCodeHeight, Mode=OneTime}" 
 						   VerticalOptions="Start" HorizontalOptions="Center" Margin="{DynamicResource SmallTopMargins}" />
-
+								<VerticalStackLayout>
+									<Label Text="{l:Localize EmbeddedLayout}" 
+										   Margin="{DynamicResource SmallTopMargins}" 
+										   VerticalOptions="Start"
+										   IsVisible="{Binding HasEmbeddedLayout}" />
+									<controls:TextButton LabelData="{l:Localize ViewEmbeddedLayout}"
+										  				 Margin="{DynamicResource SmallBottomMargins}"
+							  							 Command="{Binding Path=PresentEmbeddedLayoutCommand}" IsVisible="{Binding HasEmbeddedLayout}"
+														 IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}"
+														 Style="{DynamicResource FilledTextButton}"/>
+								</VerticalStackLayout>
 								<VerticalStackLayout>
 									<Label Text="{l:Localize Reports}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"
 											 IsVisible="{Binding HasStateMachine}"/>
+
 
 									<controls:TextButton LabelData="{l:Localize Present}" Margin="{DynamicResource SmallBottomMargins}"
 																Command="{Binding Path=PresentReportCommand}" IsVisible="{Binding HasStateMachine}"

--- a/NeuroAccessMaui/UI/Pages/Wallet/TokenDetails/TokenDetailsViewModel.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/TokenDetails/TokenDetailsViewModel.cs
@@ -16,6 +16,7 @@ using NeuroFeatures;
 using NeuroFeatures.EventArguments;
 using NeuroFeatures.Events;
 using NeuroFeatures.Tags;
+using ShimSkiaSharp;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Globalization;
@@ -93,6 +94,7 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.TokenDetails
 				this.TokenXml = this.navigationArguments.Token?.Token.ToXml();
 				this.IsMyToken = string.Equals(this.OwnerJid, ServiceRef.XmppService.BareJid, StringComparison.OrdinalIgnoreCase);
 				this.HasStateMachine = this.navigationArguments.Token?.HasStateMachine ?? false;
+				this.HasEmbeddedLayout = this.navigationArguments.Token?.HasEmbeddedLayout ?? false;
 
 				if (!string.IsNullOrEmpty(this.navigationArguments.Token?.Reference))
 				{
@@ -495,6 +497,13 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.TokenDetails
 		/// </summary>
 		[ObservableProperty]
 		private bool hasStateMachine;
+
+		/// <summary>
+		/// If the token have an embedded layout.
+		/// </summary>
+		[ObservableProperty]
+		private bool hasEmbeddedLayout;
+
 
 		#endregion
 
@@ -995,6 +1004,17 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.TokenDetails
 			{
 				await ServiceRef.UiService.DisplayException(ex);
 			}
+		}
+
+		[RelayCommand]
+		private async Task PresentEmbeddedLayout()
+		{
+			if (this.TokenId is null)
+				return;
+
+			EmbeddedLayoutNavigationArgs Args = new(this.navigationArguments.Token);
+
+			await ServiceRef.NavigationService.GoToAsync(nameof(EmbeddedLayoutPage), Args, BackMethod.Pop);
 		}
 
 		/// <summary>

--- a/NeuroAccessMaui/UI/Pages/Wallet/TokenEvents/EventItem.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/TokenEvents/EventItem.cs
@@ -55,7 +55,12 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.TokenEvents
 		/// <summary>
 		/// XML note made by an external source at the time.
 		/// </summary>
-		ExternalNoteXml
+		ExternalNoteXml,
+
+		/// <summary>
+		/// Statemachine killed.
+		/// </summary>
+		Killed,
 	}
 
 	/// <summary>
@@ -163,6 +168,8 @@ namespace NeuroAccessMaui.UI.Pages.Wallet.TokenEvents
 				return new TransferredItem(Transferred);
 			else if (Event is Donated Donated)
 				return new DonatedItem(Donated);
+			else if (Event is Killed Killed)
+				return new KilledItem(Killed);
 			else
 			{
 				return new NoteTextItem(new NoteText()

--- a/NeuroAccessMaui/UI/Pages/Wallet/TokenEvents/EventTypeTemplateSelector.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/TokenEvents/EventTypeTemplateSelector.cs
@@ -46,6 +46,11 @@
 		public DataTemplate? ExternalNoteXmlTemplate { get; set; }
 
 		/// <summary>
+		/// Template to use for killed events.
+		/// </summary>
+		public DataTemplate? KilledTemplate { get; set; }
+
+		/// <summary>
 		/// Template to use for other items.
 		/// </summary>
 		public DataTemplate? DefaultTemplate { get; set; }
@@ -65,6 +70,7 @@
 					EventType.NoteXml => this.NoteXmlTemplate ?? this.DefaultTemplate,
 					EventType.ExternalNoteText => this.ExternalNoteTextTemplate ?? this.DefaultTemplate,
 					EventType.ExternalNoteXml => this.ExternalNoteXmlTemplate ?? this.DefaultTemplate,
+					EventType.Killed => this.KilledTemplate ?? this.DefaultTemplate,
 					_ => this.DefaultTemplate,
 				};
 			}

--- a/NeuroAccessMaui/UI/Pages/Wallet/TokenEvents/Events/KilledItem.cs
+++ b/NeuroAccessMaui/UI/Pages/Wallet/TokenEvents/Events/KilledItem.cs
@@ -1,0 +1,37 @@
+﻿using NeuroAccessMaui.Services.Contacts;
+using NeuroFeatures.Events;
+
+namespace NeuroAccessMaui.UI.Pages.Wallet.TokenEvents.Events
+{
+	/// <summary>
+	/// Represents a statemachine killed event.
+	/// </summary>
+	/// <param name="Event">Token event</param>
+	public class KilledItem(Killed Event) : OwnershipEventItem(Event)
+	{
+		private readonly Killed @event = Event;
+
+		/// <summary>
+		/// Type of event.
+		/// </summary>
+		public override EventType Type => EventType.Killed;
+
+		/// <summary>
+		/// Name of the user who killed the state machine.
+		/// </summary>
+		public string User => this.@event.User;
+
+		/// <summary>
+		/// Legal identity who approvied the killing.
+		/// </summary>
+		public string LegalId => this.@event.LegalId;
+
+		/// <summary>
+		/// Binds properties
+		/// </summary>
+		public override async Task DoBind()
+		{
+			await base.DoBind();
+		}
+	}
+}

--- a/NeuroAccessMaui/UI/Pages/Wallet/TokenEvents/TokenEventsPage.xaml
+++ b/NeuroAccessMaui/UI/Pages/Wallet/TokenEvents/TokenEventsPage.xaml
@@ -15,284 +15,289 @@
 							 xmlns:events="clr-namespace:NeuroAccessMaui.UI.Pages.Wallet.TokenEvents.Events">
 	<VisualElement.Resources>
 		<DataTemplate x:Key="CreatedEvent" x:DataType="events:CreatedItem">
-			<ViewCell>
-				<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto,auto,auto" Margin="{DynamicResource SmallBottomMargins}">
-					<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
-								<Span Text=", "/>
-								<Span Text="{l:Localize Created}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
+			<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto,auto,auto" Margin="{DynamicResource SmallBottomMargins}">
+				<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
+							<Span Text=", "/>
+							<Span Text="{l:Localize Created}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Creator}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="1" Text="{Binding CreatorFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Creator}" />
-						</Label.GestureRecognizers>
-					</Label>
+				<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Creator}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="1" Text="{Binding CreatorFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Creator}" />
+					</Label.GestureRecognizers>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize Owner}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
-						</Label.GestureRecognizers>
-					</Label>
+				<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize Owner}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
+					</Label.GestureRecognizers>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize OwnershipContract}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="3" Text="{Binding OwnershipContract}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding OwnershipContract}" />
-						</Label.GestureRecognizers>
-					</Label>
+				<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize OwnershipContract}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="3" Text="{Binding OwnershipContract}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding OwnershipContract}" />
+					</Label.GestureRecognizers>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="4" Text="{l:Localize Value}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="4" Style="{DynamicResource ValueLabel}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Value, Converter={converters:MoneyToString}}"/>
-								<Span Text=" "/>
-								<Span Text="{Binding Currency}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
-				</Grid>
-			</ViewCell>
+				<Label Grid.Column="0" Grid.Row="4" Text="{l:Localize Value}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="4" Style="{DynamicResource ValueLabel}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Value, Converter={converters:MoneyToString}}"/>
+							<Span Text=" "/>
+							<Span Text="{Binding Currency}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
+			</Grid>
 		</DataTemplate>
 		<DataTemplate x:Key="DestroyedEvent" x:DataType="events:DestroyedItem">
-			<ViewCell>
-				<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto,auto" Margin="{DynamicResource SmallBottomMargins}">
-					<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
-								<Span Text=", "/>
-								<Span Text="{l:Localize Destroyed}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
+			<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto,auto" Margin="{DynamicResource SmallBottomMargins}">
+				<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
+							<Span Text=", "/>
+							<Span Text="{l:Localize Destroyed}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Owner}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="1" Text="{Binding OwnerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
-						</Label.GestureRecognizers>
-					</Label>
+				<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Owner}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="1" Text="{Binding OwnerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
+					</Label.GestureRecognizers>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize OwnershipContract}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnershipContract}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding OwnershipContract}" />
-						</Label.GestureRecognizers>
-					</Label>
+				<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize OwnershipContract}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnershipContract}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding OwnershipContract}" />
+					</Label.GestureRecognizers>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize Value}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="3" Style="{DynamicResource ValueLabel}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Value, Converter={converters:MoneyToString}}"/>
-								<Span Text=" "/>
-								<Span Text="{Binding Currency}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
-				</Grid>
-			</ViewCell>
+				<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize Value}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="3" Style="{DynamicResource ValueLabel}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Value, Converter={converters:MoneyToString}}"/>
+							<Span Text=" "/>
+							<Span Text="{Binding Currency}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
+			</Grid>
 		</DataTemplate>
 		<DataTemplate x:Key="TransferredEvent" x:DataType="events:TransferredItem">
-			<ViewCell>
-				<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto,auto,auto" Margin="{DynamicResource SmallBottomMargins}">
-					<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
-								<Span Text=", "/>
-								<Span Text="{l:Localize Transferred}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
+			<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto,auto,auto" Margin="{DynamicResource SmallBottomMargins}">
+				<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
+							<Span Text=", "/>
+							<Span Text="{l:Localize Transferred}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Seller}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="1" Text="{Binding SellerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Seller}" />
-						</Label.GestureRecognizers>
-					</Label>
+				<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Seller}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="1" Text="{Binding SellerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Seller}" />
+					</Label.GestureRecognizers>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize Owner}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
-						</Label.GestureRecognizers>
-					</Label>
+				<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize Owner}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
+					</Label.GestureRecognizers>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize OwnershipContract}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="3" Text="{Binding OwnershipContract}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding OwnershipContract}" />
-						</Label.GestureRecognizers>
-					</Label>
+				<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize OwnershipContract}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="3" Text="{Binding OwnershipContract}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding OwnershipContract}" />
+					</Label.GestureRecognizers>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="4" Text="{l:Localize Value}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="4" Style="{DynamicResource ValueLabel}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Value, Converter={converters:MoneyToString}}"/>
-								<Span Text=" "/>
-								<Span Text="{Binding Currency}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
-				</Grid>
-			</ViewCell>
+				<Label Grid.Column="0" Grid.Row="4" Text="{l:Localize Value}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="4" Style="{DynamicResource ValueLabel}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Value, Converter={converters:MoneyToString}}"/>
+							<Span Text=" "/>
+							<Span Text="{Binding Currency}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
+			</Grid>
 		</DataTemplate>
 		<DataTemplate x:Key="DonatedEvent" x:DataType="events:DonatedItem">
-			<ViewCell>
-				<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto,auto" Margin="{DynamicResource SmallBottomMargins}">
-					<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
-								<Span Text=", "/>
-								<Span Text="{l:Localize Donated}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
+			<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto,auto" Margin="{DynamicResource SmallBottomMargins}">
+				<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
+							<Span Text=", "/>
+							<Span Text="{l:Localize Donated}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Donor}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="1" Text="{Binding DonorFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Donor}" />
-						</Label.GestureRecognizers>
-					</Label>
+				<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize Donor}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="1" Text="{Binding DonorFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Donor}" />
+					</Label.GestureRecognizers>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize Owner}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
-						</Label.GestureRecognizers>
-					</Label>
+				<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize Owner}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="2" Text="{Binding OwnerFriendlyName}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
+					</Label.GestureRecognizers>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize OwnershipContract}" Style="{DynamicResource KeyLabel}"/>
-					<Label Grid.Column="1" Grid.Row="3" Text="{Binding OwnershipContract}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding OwnershipContract}" />
-						</Label.GestureRecognizers>
-					</Label>
-				</Grid>
-			</ViewCell>
+				<Label Grid.Column="0" Grid.Row="3" Text="{l:Localize OwnershipContract}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="3" Text="{Binding OwnershipContract}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewContractCommand}" CommandParameter="{Binding OwnershipContract}" />
+					</Label.GestureRecognizers>
+				</Label>
+			</Grid>
 		</DataTemplate>
 		<DataTemplate x:Key="NoteText" x:DataType="events:NoteTextItem">
-			<ViewCell>
-				<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto" Margin="{DynamicResource SmallBottomMargins}">
-					<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
-								<Span Text=", "/>
-								<Span Text="{l:Localize TextNote}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
+			<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto" Margin="{DynamicResource SmallBottomMargins}">
+				<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
+							<Span Text=", "/>
+							<Span Text="{l:Localize TextNote}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding Note}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Note}" />
-						</Label.GestureRecognizers>
-					</Label>
-				</Grid>
-			</ViewCell>
+				<Label Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding Note}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Note}" />
+					</Label.GestureRecognizers>
+				</Label>
+			</Grid>
 		</DataTemplate>
 		<DataTemplate x:Key="NoteXml" x:DataType="events:NoteXmlItem">
-			<ViewCell>
-				<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto" Margin="{DynamicResource SmallBottomMargins}">
-					<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
-								<Span Text=", "/>
-								<Span Text="{l:Localize XmlNote}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
-					<Label Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Text="{l:Localize ViewXmlInBrowser}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewXmlInBrowserCommand}" CommandParameter="{Binding Note}" />
-						</Label.GestureRecognizers>
-					</Label>
-				</Grid>
-			</ViewCell>
+			<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto" Margin="{DynamicResource SmallBottomMargins}">
+				<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
+							<Span Text=", "/>
+							<Span Text="{l:Localize XmlNote}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
+				<Label Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Text="{l:Localize ViewXmlInBrowser}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewXmlInBrowserCommand}" CommandParameter="{Binding Note}" />
+					</Label.GestureRecognizers>
+				</Label>
+			</Grid>
 		</DataTemplate>
 		<DataTemplate x:Key="ExternalNoteText" x:DataType="events:ExternalNoteTextItem">
-			<ViewCell>
-				<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto" Margin="{DynamicResource SmallBottomMargins}">
-					<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
-								<Span Text=", "/>
-								<Span Text="{l:Localize TextNote}"/>
-								<Span Text="{x:Static system:Environment.NewLine}"/>
-								<Span Text="(" Style="{DynamicResource ValueSpan}"/>
-								<Span Text="{l:Localize From}" Style="{DynamicResource ValueSpan}"/>
-								<Span Text=" " Style="{DynamicResource ValueSpan}"/>
-								<Span Text="{Binding Source}" Style="{DynamicResource ClickableValueSpan}">
-									<Span.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding ViewSourceCommand}" CommandParameter="{Binding Source}" />
-									</Span.GestureRecognizers>
-								</Span>
-								<Span Text=")" Style="{DynamicResource ValueSpan}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
+			<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto" Margin="{DynamicResource SmallBottomMargins}">
+				<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
+							<Span Text=", "/>
+							<Span Text="{l:Localize TextNote}"/>
+							<Span Text="{x:Static system:Environment.NewLine}"/>
+							<Span Text="(" Style="{DynamicResource ValueSpan}"/>
+							<Span Text="{l:Localize From}" Style="{DynamicResource ValueSpan}"/>
+							<Span Text=" " Style="{DynamicResource ValueSpan}"/>
+							<Span Text="{Binding Source}" Style="{DynamicResource ClickableValueSpan}">
+								<Span.GestureRecognizers>
+									<TapGestureRecognizer Command="{Binding ViewSourceCommand}" CommandParameter="{Binding Source}" />
+								</Span.GestureRecognizers>
+							</Span>
+							<Span Text=")" Style="{DynamicResource ValueSpan}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
 
-					<Label Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding Note}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Note}" />
-						</Label.GestureRecognizers>
-					</Label>
-				</Grid>
-			</ViewCell>
+				<Label Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Text="{Binding Note}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding CopyToClipboardCommand}" CommandParameter="{Binding Note}" />
+					</Label.GestureRecognizers>
+				</Label>
+			</Grid>
 		</DataTemplate>
 		<DataTemplate x:Key="ExternalNoteXml" x:DataType="events:ExternalNoteXmlItem">
-			<ViewCell>
-				<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto" Margin="{DynamicResource SmallBottomMargins}">
-					<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
-						<Label.FormattedText>
-							<FormattedString>
-								<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
-								<Span Text=", "/>
-								<Span Text="{l:Localize XmlNote}"/>
-								<Span Text="{x:Static system:Environment.NewLine}"/>
-								<Span Text="(" Style="{DynamicResource ValueSpan}"/>
-								<Span Text="{l:Localize From}" Style="{DynamicResource ValueSpan}"/>
-								<Span Text=" " Style="{DynamicResource ValueSpan}"/>
-								<Span Text="{Binding Source}" Style="{DynamicResource ClickableValueSpan}">
-									<Span.GestureRecognizers>
-										<TapGestureRecognizer Command="{Binding ViewSourceCommand}" CommandParameter="{Binding Source}" />
-									</Span.GestureRecognizers>
-								</Span>
-								<Span Text=")" Style="{DynamicResource ValueSpan}"/>
-							</FormattedString>
-						</Label.FormattedText>
-					</Label>
-					<Label Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Text="{l:Localize ViewXmlInBrowser}" Style="{DynamicResource ClickableValueLabel}">
-						<Label.GestureRecognizers>
-							<TapGestureRecognizer Command="{Binding ViewXmlInBrowserCommand}" CommandParameter="{Binding Note}" />
-						</Label.GestureRecognizers>
-					</Label>
-				</Grid>
-			</ViewCell>
+			<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto" Margin="{DynamicResource SmallBottomMargins}">
+				<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
+							<Span Text=", "/>
+							<Span Text="{l:Localize XmlNote}"/>
+							<Span Text="{x:Static system:Environment.NewLine}"/>
+							<Span Text="(" Style="{DynamicResource ValueSpan}"/>
+							<Span Text="{l:Localize From}" Style="{DynamicResource ValueSpan}"/>
+							<Span Text=" " Style="{DynamicResource ValueSpan}"/>
+							<Span Text="{Binding Source}" Style="{DynamicResource ClickableValueSpan}">
+								<Span.GestureRecognizers>
+									<TapGestureRecognizer Command="{Binding ViewSourceCommand}" CommandParameter="{Binding Source}" />
+								</Span.GestureRecognizers>
+							</Span>
+							<Span Text=")" Style="{DynamicResource ValueSpan}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
+				<Label Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Text="{l:Localize ViewXmlInBrowser}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewXmlInBrowserCommand}" CommandParameter="{Binding Note}" />
+					</Label.GestureRecognizers>
+				</Label>
+			</Grid>
+		</DataTemplate>
+		<DataTemplate x:Key="Killed" x:DataType="events:KilledItem">
+			<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto,auto" Margin="{DynamicResource SmallBottomMargins}">
+				<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Style="{DynamicResource TableHeader}">
+					<Label.FormattedText>
+						<FormattedString>
+							<Span Text="{Binding Timestamp, Converter={converters:DateTimeToString}}"/>
+							<Span Text=", "/>
+							<Span Text="{l:Localize Killed}"/>
+						</FormattedString>
+					</Label.FormattedText>
+				</Label>
+
+				<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize KillerUser}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="1" Text="{Binding User}" Style="{DynamicResource ClickableValueLabel}"/>
+
+				<Label Grid.Column="0" Grid.Row="2" Text="{l:Localize KillerId}" Style="{DynamicResource KeyLabel}"/>
+				<Label Grid.Column="1" Grid.Row="2" Text="{Binding LegalId}" Style="{DynamicResource ClickableValueLabel}">
+					<Label.GestureRecognizers>
+						<TapGestureRecognizer Command="{Binding ViewIdCommand}" CommandParameter="{Binding Owner}" />
+					</Label.GestureRecognizers>
+				</Label>
+			</Grid>
 		</DataTemplate>
 		<DataTemplate x:Key="OtherEvents" x:DataType="viewmodel:EventItem">
-			<ViewCell>
-				<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto" Margin="{DynamicResource SmallBottomMargins}">
-					<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Text="{Binding Timestamp, Converter={converters:DateTimeToString}}" Style="{DynamicResource TableHeader}"/>
-					<Label Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Text="{l:Localize UnrecognizedEventType}" Style="{DynamicResource ValueLabel}"/>
-				</Grid>
-			</ViewCell>
+			<Grid ColumnDefinitions="*,*" RowDefinitions="auto,auto" Margin="{DynamicResource SmallBottomMargins}">
+				<Label Grid.Column="0" Grid.Row="0" Grid.ColumnSpan="2" Text="{Binding Timestamp, Converter={converters:DateTimeToString}}" Style="{DynamicResource TableHeader}"/>
+				<Label Grid.Column="0" Grid.Row="1" Grid.ColumnSpan="2" Text="{l:Localize UnrecognizedEventType}" Style="{DynamicResource ValueLabel}"/>
+			</Grid>
 		</DataTemplate>
 		<viewmodel:EventTypeTemplateSelector x:Key="EventStyleSelector" 
 														 CreatedTemplate="{StaticResource CreatedEvent}" 
@@ -303,25 +308,25 @@
 														 NoteXmlTemplate="{StaticResource NoteXml}"
 														 ExternalNoteTextTemplate="{StaticResource ExternalNoteText}" 
 														 ExternalNoteXmlTemplate="{StaticResource ExternalNoteXml}"
+														 KilledTemplate="{StaticResource Killed}"
 														 DefaultTemplate="{StaticResource OtherEvents}"/>
 	</VisualElement.Resources>
-	<Grid BackgroundColor="{DynamicResource SurfaceBackgroundWL}">
-
-		<controls:Background/>
-
-		<ScrollView>
-			<VerticalStackLayout Spacing="{DynamicResource SmallSpacing}" Margin="{DynamicResource MediumSpacing}">
-				<controls:ImageButton HorizontalOptions="Start" Command="{Binding GoBackCommand}"
-											 Style="{DynamicResource ImageOnlyButton}" PathData="{x:Static ui:Geometries.BackButtonPath}" />
-
-				<Label Text="{l:Localize TokenEvents}" Style="{DynamicResource PageTitleLabel}"/>
-
+	<Grid BackgroundColor="{DynamicResource SurfaceBackgroundWL}" RowDefinitions="auto, *">
+		<controls:Background Grid.RowSpan="2"/>
+		<Grid ColumnDefinitions="auto, *, auto" Margin="16,8,16,0">
+			<controls:SvgButton Command="{Binding GoBackCommand}"
+								  Style="{DynamicResource IconButton}"
+								  SvgSource="close.svg"/>
+			<Label Grid.Column="2" Text="{l:Localize TokenEvents}" Style="{DynamicResource PageTitleLabel}"/>
+		</Grid>
+		<ScrollView Grid.Row="1" Margin="8">
+			<VerticalStackLayout Spacing="{DynamicResource SmallSpacing}" >
 				<Border Style="{DynamicResource BorderSet}">
-					<Grid ColumnDefinitions="*" RowDefinitions="auto,auto,*,auto" Margin="{DynamicResource SmallMargins}">
+					<Grid ColumnDefinitions="*" RowDefinitions="auto,auto,*,auto">
 						<Label Grid.Column="0" Grid.Row="0" Text="{l:Localize TokenEvents}" Margin="{DynamicResource SmallTopMargins}" VerticalOptions="Start"/>
 						<Label Grid.Column="0" Grid.Row="1" Text="{l:Localize TokenEventsDescription}" Style="{DynamicResource InfoLabel}" VerticalOptions="Start"/>
-						<ListView Grid.Column="0" Grid.Row="2" HasUnevenRows="True" SeparatorVisibility="None" VerticalOptions="Start"
-								  ItemsSource="{Binding Path=Events}" ItemTemplate="{StaticResource EventStyleSelector}"/>
+						<VerticalStackLayout Grid.Column="0" Grid.Row="2" VerticalOptions="Start"
+								  BindableLayout.ItemsSource="{Binding Path=Events}" BindableLayout.ItemTemplateSelector="{StaticResource EventStyleSelector}" />
 						<controls:TextButton Grid.Column="0" Grid.Row="3" LabelData="{l:Localize AddNote}" Margin="{DynamicResource SmallBottomMargins}"
 													Command="{Binding Path=AddNoteCommand}" Style="{DynamicResource FilledTextButton}"
 													IsEnabled="{Binding Path=IsBusy, Converter={StaticResource InvertedBoolConverter}}" />


### PR DESCRIPTION
# Viewing token embedded layouts and statemachine killed event

## 📋 Description

Added a view embedded layout section and button to the token details page which directs the user to a new embedded layout page which shows a tokens embedded layout. Also added the killed statemachine event to the token event view.

**What kind of change does this PR introduce?**

* [ ] Bug fix
* [x] New feature
* [ ] Documentation update
* [ ] Refactoring
* [ ] Performance improvement
* [ ] Other (please describe): \_\_\_\_\_\_\_\_\_\_

## 📝 Related Issues

Closes: #316 

## 🔄 Changelog

### Added

* Viewing tokens embedded layouts.
* State machine killed events on tokens event view
