### PR TITLE
Crl fix cv

### DIFF
--- a/NeuroAccess.Nfc.Test/CrlTests.cs
+++ b/NeuroAccess.Nfc.Test/CrlTests.cs
@@ -1,0 +1,21 @@
+using NeuroAccess.Nfc.TravelDocuments.RevocationLists;
+
+namespace NeuroAccess.Nfc.Test
+{
+	[TestClass]
+	public class CrlTests
+	{
+		[TestMethod]
+		public void Test_01_ParseCrlWithoutRevokedCertificates()
+		{
+			// Finnish CSCA CRL without a revokedCertificates sequence.
+			// Source: http://proxy.fineid.fi/crl/cscafinc.crl
+			byte[] Bin = Convert.FromBase64String(
+				"MIIBQzCBpwIBATAMBggqhkjOPQQDBAUAMEQxCzAJBgNVBAYTAkZJMRAwDgYDVQQKDAdGaW5sYW5kMQwwCgYDVQQLDANWUksxFTATBgNVBAMMDENTQ0EgRmlubGFuZBcNMjYwNzIzMDcxOTU4WhcNMjYwOTAxMDcxOTU4WqAwMC4wHwYDVR0jBBgwFoAUqYvqjNOZ0P8SvNhU0jdH5hofwAQwCwYDVR0UBAQCAgFBMAwGCCqGSM49BAMEBQADgYgAMIGEAkBbrEa0EZBYa+fl6bZuy0JhoOpf+g/uEAndjdPsLYVVSDrGjG/DoW5/VlfGAmFe4or0F3tHljbf1xgape88h0c6AkBoR+pTfZ1WahlaAYe8pfDD+aBB3cq1HiI/DlVU75yxAseYK07Y3TxGBTz5sBn509uhKAsHaeX7F11fUztDRtWu");
+
+			Assert.IsTrue(CertificateList.TryParse(Bin, out CertificateList? Crl));
+			Assert.IsNotNull(Crl);
+			Assert.AreEqual(0, Crl.RevokedCertificates.Length);
+		}
+	}
+}

--- a/NeuroAccess.Nfc/TravelDocuments/RevocationLists/CertificateList.cs
+++ b/NeuroAccess.Nfc/TravelDocuments/RevocationLists/CertificateList.cs
@@ -68,10 +68,15 @@ namespace NeuroAccess.Nfc.TravelDocuments.RevocationLists
 			if (CertificateListVector.FirstElement is not Vector TbsCertList)
 				return false;
 
-			if (CertificateListVector[1] is not Vector AlgorithmIdentifier)
+			ISignatureAlgorithm? SignatureAlgorithm;
+
+			if (CertificateListVector[1] is ISignatureAlgorithm Algorithm)
+				SignatureAlgorithm = Algorithm;
+			else if (CertificateListVector[1] is Vector AlgorithmIdentifier)
+				SignatureAlgorithm = Security.SignatureAlgorithms.SignatureAlgorithm.TryDecode(AlgorithmIdentifier);
+			else
 				return false;
 
-			ISignatureAlgorithm? SignatureAlgorithm = Security.SignatureAlgorithms.SignatureAlgorithm.TryDecode(AlgorithmIdentifier);
 			if (SignatureAlgorithm is null)
 				return false;
 

--- a/NeuroAccess.Nfc/TravelDocuments/RevocationLists/ToBeSignedCertificateList.cs
+++ b/NeuroAccess.Nfc/TravelDocuments/RevocationLists/ToBeSignedCertificateList.cs
@@ -1,4 +1,4 @@
-using NeuroAccess.Nfc.TravelDocuments.Certificates;
+﻿using NeuroAccess.Nfc.TravelDocuments.Certificates;
 using NeuroAccess.Nfc.TravelDocuments.Security;
 using NeuroAccess.Nfc.TravelDocuments.Security.Properties.Keys;
 using NeuroAccess.Nfc.TravelDocuments.Security.SignatureAlgorithms;
@@ -111,12 +111,19 @@ namespace NeuroAccess.Nfc.TravelDocuments.RevocationLists
 			else
 				NextUpdate = DateTime.MaxValue;
 
-			if (i >= c || TbsCertList[i++] is not Vector RevokedCertificates)
-				return false;
+			// ICAO Doc 9303-12, Table 9:
+			// https://www.icao.int/sites/default/files/publications/DocSeries/9303_p12_cons_en.pdf#page=43
+			// The revokedCertificates sequence is omitted when no certificates are revoked.
+			System.Collections.IEnumerable RevokedCertificateEntries = Array.Empty<object>();
+			if (i < c && TbsCertList[i] is Sequence RevokedCertificatesSequence)
+			{
+				i++;
+				RevokedCertificateEntries = RevokedCertificatesSequence;
+			}
 
 			ChunkedList<RevokedCertificate> RevokedCertificates2 = [];
 
-			foreach (object? Item in RevokedCertificates)
+			foreach (object? Item in RevokedCertificateEntries)
 			{
 				if (Item is not Vector RevokedCertificate)
 					return false;

--- a/NeuroAccess.Nfc/TravelDocuments/RevocationLists/ToBeSignedCertificateList.cs
+++ b/NeuroAccess.Nfc/TravelDocuments/RevocationLists/ToBeSignedCertificateList.cs
@@ -1,4 +1,4 @@
-﻿using NeuroAccess.Nfc.TravelDocuments.Certificates;
+using NeuroAccess.Nfc.TravelDocuments.Certificates;
 using NeuroAccess.Nfc.TravelDocuments.Security;
 using NeuroAccess.Nfc.TravelDocuments.Security.Properties.Keys;
 using NeuroAccess.Nfc.TravelDocuments.Security.SignatureAlgorithms;
@@ -84,10 +84,19 @@ namespace NeuroAccess.Nfc.TravelDocuments.RevocationLists
 				i++;
 			}
 
-			if (i >= c || TbsCertList[i++] is not Vector AlgorithmIdentifier)
+			if (i >= c)
 				return false;
 
-			ISignatureAlgorithm? SignatureAlgorithm = Security.SignatureAlgorithms.SignatureAlgorithm.TryDecode(AlgorithmIdentifier);
+			object? AlgorithmIdentifier = TbsCertList[i++];
+			ISignatureAlgorithm? SignatureAlgorithm;
+
+			if (AlgorithmIdentifier is ISignatureAlgorithm Algorithm)
+				SignatureAlgorithm = Algorithm;
+			else if (AlgorithmIdentifier is Vector AlgorithmIdentifierVector)
+				SignatureAlgorithm = Security.SignatureAlgorithms.SignatureAlgorithm.TryDecode(AlgorithmIdentifierVector);
+			else
+				return false;
+
 			if (SignatureAlgorithm is null)
 				return false;
 

--- a/NeuroAccess.Nfc/TravelDocuments/RevocationLists/ToBeSignedCertificateList.cs
+++ b/NeuroAccess.Nfc/TravelDocuments/RevocationLists/ToBeSignedCertificateList.cs
@@ -114,16 +114,16 @@ namespace NeuroAccess.Nfc.TravelDocuments.RevocationLists
 			// ICAO Doc 9303-12, Table 9:
 			// https://www.icao.int/sites/default/files/publications/DocSeries/9303_p12_cons_en.pdf#page=43
 			// The revokedCertificates sequence is omitted when no certificates are revoked.
-			System.Collections.IEnumerable RevokedCertificateEntries = Array.Empty<object>();
+			System.Collections.IEnumerable RevokedCertificates = Array.Empty<object>();
 			if (i < c && TbsCertList[i] is Sequence RevokedCertificatesSequence)
 			{
 				i++;
-				RevokedCertificateEntries = RevokedCertificatesSequence;
+				RevokedCertificates = RevokedCertificatesSequence;
 			}
 
 			ChunkedList<RevokedCertificate> RevokedCertificates2 = [];
 
-			foreach (object? Item in RevokedCertificateEntries)
+			foreach (object? Item in RevokedCertificates)
 			{
 				if (Item is not Vector RevokedCertificate)
 					return false;


### PR DESCRIPTION
Valid Certificate Revocation Lists do not contain a `revokedCertificates` section when no certificates have been revoked.

The parser previously required this section, which caused the Finnish CRL to fail.

This change:

- Treats a missing `revokedCertificates` section as an empty list.
- Supports CRLs where the ASN.1 parser has already recognized and configured the signature algorithm
- Adds a test using the public Finnish CRL.

ICAO Doc 9303 Part 12, Table 9 says the section must be omitted when there are no revoked certificates:

[[ICAO Doc 9303 Part 12](https://www.icao.int/sites/default/files/publications/DocSeries/9303_p12_cons_en.pdf#page=43)](https://www.icao.int/sites/default/files/publications/DocSeries/9303_p12_cons_en.pdf#page=43)

Also added 1 test for finish CRL where this issue could be reproduced